### PR TITLE
Fix pages release permissions issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,8 @@ jobs:
               core.info('Uploaded ' + name);
             }
   publish-docs:
+    permissions:
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhacement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
GitHub Pages release of docs is failing due to missing permissions. This adds the missing permissions to the job in the workflow.

## Testing

- [X] The Unit & Intergration tests are passing.
- [X] I have added the necesary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
