### PR TITLE
Fixed Integration Test for Component and Route property binding

### DIFF
--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ComplexModelBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ComplexModelBindingFixture.cs
@@ -76,10 +76,10 @@ public class ComplexModelBindingFixture : IDisposable
             .Should().Be(TestConstants.SearchKeywords);
 
         sectionNode.ChildNodes.First(n => n.Id.Equals("componentProperty", StringComparison.OrdinalIgnoreCase)).InnerText
-            .Should().BeEmpty("Complex-Component");
+            .Should().Be("Complex-Component");
 
         sectionNode.ChildNodes.First(n => n.Id.Equals("routeProperty", StringComparison.OrdinalIgnoreCase)).InnerText.
-            Should().BeEmpty("styleguide");
+            Should().Be("styleguide");
 
         sectionNode.ChildNodes.First(n => n.Id.Equals("fieldContent", StringComparison.OrdinalIgnoreCase)).InnerHtml.
             Should().Be(TestConstants.RichTextFieldValue1);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComplexComponent.cshtml
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComplexComponent.cshtml
@@ -3,8 +3,8 @@
 <section class="complex-component">
     <h1 id="fieldHeader" asp-for="Header"></h1>
     <h2 id="routeField" asp-for="PageTitle"></h2>
-    <h3 id="componentProperty" asp-for="ComponentName"></h3>
-    <p id="routeProperty" asp-for="RouteName"></p>
+    <h3 id="componentProperty">@Model.ComponentName</h3>
+    <p id="routeProperty">@Model.RouteName</p>
     <p id="routeNestedField" asp-for="RouteFields!.SearchKeywords"></p>
     <div id="fieldContent" asp-for="Content"></div>
     <textarea id="contextProperty" asp-for="IsEditing"></textarea>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhacement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The integration test for Component and Route property binding mistakenly had `BeEmpty()` instead of `Be()`. This incorrectly made the integration test pass since the Razor View was invalid. It was using the `asp-for` TagHelper attribute to attempt to render the values. However the Model's properties are of type `string?` which do not have an OOTB TagHelper for the `h3` or `p` tags. With the view fixed this test now properly passes and behaves as expected.

## Testing

- [X] The Unit & Intergration tests are passing.
- [X] I have added the necesary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
