### PR TITLE
Fixed issue rendering nested empty placeholders

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
@@ -70,8 +70,12 @@ public class PlaceholderTagHelper(
             return;
         }
 
-        bool foundPlaceholderFeatures = false;
+        if (IsInEditingMode(renderingContext) && IsPlaceHolderEmpty(placeholderFeatures))
+        {
+            output.Content.AppendHtml("<div class=\"sc-empty-placeholder\">");
+        }
 
+        bool foundPlaceholderFeatures = false;
         foreach (IPlaceholderFeature placeholderFeature in placeholderFeatures.OfType<IPlaceholderFeature>())
         {
             foundPlaceholderFeatures = true;
@@ -98,10 +102,25 @@ public class PlaceholderTagHelper(
             output.Content.AppendHtml(html);
         }
 
+        if (IsInEditingMode(renderingContext) && IsPlaceHolderEmpty(placeholderFeatures))
+        {
+            output.Content.AppendHtml("</div>");
+        }
+
         if (!foundPlaceholderFeatures)
         {
             output.Content.SetHtmlContent($"<div className=\"sc-jss-empty-placeholder\"></div>");
         }
+    }
+
+    private static bool IsInEditingMode(ISitecoreRenderingContext renderingContext)
+    {
+        return renderingContext?.Response?.Content?.Sitecore?.Context?.IsEditing ?? false;
+    }
+
+    private static bool IsPlaceHolderEmpty(Placeholder placeholderFeatures)
+    {
+        return !placeholderFeatures.Exists(x => x is Component);
     }
 
     private static Placeholder? GetPlaceholderFeatures(string placeholderName, ISitecoreRenderingContext renderingContext)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
@@ -128,12 +128,14 @@ public class PlaceholderTagHelper(
         Placeholder? placeholderFeatures = null;
 
         // try to get the placeholder from the "context" component
-        if (renderingContext.Component?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures) ?? false)
+        renderingContext.Component?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures);
+
+        // top level placeholders do not have a "context" component set, so their component list can be retrieved directly from the Sitecore Route object
+        if (placeholderFeatures?.Count > 0)
         {
             return placeholderFeatures;
         }
 
-        // top level placeholders do not have a "context" component set, so their component list can be retrieved directly from the Sitecore Route object
         Route? route = renderingContext.Response?.Content?.Sitecore?.Route;
         route?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures);
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
@@ -100,7 +100,7 @@ public class PlaceholderTagHelper(
 
         if (!foundPlaceholderFeatures)
         {
-            output.Content.SetHtmlContent($"<!-- {string.Format(Resources.Warning_PlaceholderWasEmpty, placeholderName)} -->");
+            output.Content.SetHtmlContent($"<div className=\"sc-jss-empty-placeholder\"></div>");
         }
     }
 
@@ -109,14 +109,12 @@ public class PlaceholderTagHelper(
         Placeholder? placeholderFeatures = null;
 
         // try to get the placeholder from the "context" component
-        renderingContext.Component?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures);
-
-        // top level placeholders do not have a "context" component set, so their component list can be retrieved directly from the Sitecore Route object
-        if (placeholderFeatures?.Count > 0)
+        if (renderingContext.Component?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures) ?? false)
         {
             return placeholderFeatures;
         }
 
+        // top level placeholders do not have a "context" component set, so their component list can be retrieved directly from the Sitecore Route object
         Route? route = renderingContext.Response?.Content?.Sitecore?.Route;
         route?.Placeholders.TryGetValue(placeholderName, out placeholderFeatures);
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
@@ -70,7 +70,8 @@ public class PlaceholderTagHelper(
             return;
         }
 
-        if (IsInEditingMode(renderingContext) && IsPlaceHolderEmpty(placeholderFeatures))
+        bool emptyEdit = IsInEditingMode(renderingContext) && IsPlaceHolderEmpty(placeholderFeatures);
+        if (emptyEdit)
         {
             output.Content.AppendHtml("<div class=\"sc-empty-placeholder\">");
         }
@@ -102,7 +103,7 @@ public class PlaceholderTagHelper(
             output.Content.AppendHtml(html);
         }
 
-        if (IsInEditingMode(renderingContext) && IsPlaceHolderEmpty(placeholderFeatures))
+        if (emptyEdit)
         {
             output.Content.AppendHtml("</div>");
         }
@@ -115,7 +116,7 @@ public class PlaceholderTagHelper(
 
     private static bool IsInEditingMode(ISitecoreRenderingContext renderingContext)
     {
-        return renderingContext?.Response?.Content?.Sitecore?.Context?.IsEditing ?? false;
+        return renderingContext.Response?.Content?.Sitecore?.Context?.IsEditing ?? false;
     }
 
     private static bool IsPlaceHolderEmpty(Placeholder placeholderFeatures)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/PlaceholderTagHelper.cs
@@ -109,7 +109,7 @@ public class PlaceholderTagHelper(
 
         if (!foundPlaceholderFeatures)
         {
-            output.Content.SetHtmlContent($"<div className=\"sc-jss-empty-placeholder\"></div>");
+            output.Content.SetHtmlContent($"<!-- {string.Format(Resources.Warning_PlaceholderWasEmpty, placeholderName)} -->");
         }
     }
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -478,6 +478,53 @@ public class PlaceholderTagHelperFixture
 
     [Theory]
     [AutoNSubstituteData]
+    public async Task ProcessAsync_PlaceholderContainsUnknownPlaceholderFeature_IsInEditingMode_OutputIsEditingWrapperTag(
+        PlaceholderTagHelper sut,
+        ViewContext viewContext,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        SitecoreRenderingContext context = new()
+        {
+            Response = new SitecoreLayoutResponse([])
+            {
+                Content = new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Context = new Context { IsEditing = true },
+                        Route = new Route
+                        {
+                            Placeholders =
+                            {
+                                [PlaceHolderWithComponentsName] =
+                                [
+                                    new TestPlaceholderFeature
+                                    {
+                                        Content = TestComponentRenderer.HtmlContent
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        viewContext.HttpContext.SetSitecoreRenderingContext(context);
+        sut.Name = PlaceHolderWithComponentsName;
+        sut.ViewContext = viewContext;
+
+        // Act
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Content.GetContent().Should().Be("<div class=\"sc-empty-placeholder\"></div>");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
     public async Task ProcessAsync_PlaceholderNameInLayoutServiceResponseAndPlaceholderIsNotEmpty_ContextComponentDoNotChange(
         PlaceholderTagHelper sut,
         ViewContext viewContext,

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -236,7 +236,7 @@ public class PlaceholderTagHelperFixture
         await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
 
         // Assert
-        tagHelperOutput.Content.GetContent().Should().Be($"<!-- Placeholder '{PlaceHolderWithNoComponentsName}' was empty. -->");
+        tagHelperOutput.Content.GetContent().Should().Be($"<div className=\"sc-jss-empty-placeholder\"></div>");
     }
 
     [Theory]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -236,7 +236,7 @@ public class PlaceholderTagHelperFixture
         await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
 
         // Assert
-        tagHelperOutput.Content.GetContent().Should().Be($"<div className=\"sc-jss-empty-placeholder\"></div>");
+        tagHelperOutput.Content.GetContent().Should().Be($"<!-- Placeholder '{PlaceHolderWithNoComponentsName}' was empty. -->");
     }
 
     [Theory]


### PR DESCRIPTION
Currently, empty Placeholders are not rendering the same HTML that JSS does. This PR updates the SDK's TagHelper to generate HTML that matches the same output from JSS.

## Description / Motivation
When a Placeholder is rendered without any components loaded inside of it, it needs to be wrapped in a div to be correctly rendered in Pages and Experience Editor.  The div being created by for this SDK is `<div className=\"sc-empty-placeholder\"></div>`

## Testing
- [x] The Unit & Intergration tests are passing.
- [x] I have added the necesary tests to cover my changes.

## Terms
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
