### PR TITLE
Add GetRawValue() to return raw JSON in JsonSerializedField.

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Fields/JsonSerializedField.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Fields/JsonSerializedField.cs
@@ -19,6 +19,12 @@ public class JsonSerializedField(JsonDocument doc)
     private readonly string _json = doc != null ? doc.RootElement.GetRawText() : throw new ArgumentNullException(nameof(doc));
 
     /// <inheritdoc/>
+    public override string ToString()
+    {
+        return _json;
+    }
+
+    /// <inheritdoc/>
     protected override object? HandleRead(Type type)
     {
         // NOTE The JsonSerializerOptions used to be delivered through the deserialization but are now locked here inside the class because

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Fields/JsonSerializedField.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Fields/JsonSerializedField.cs
@@ -18,8 +18,11 @@ public class JsonSerializedField(JsonDocument doc)
 
     private readonly string _json = doc != null ? doc.RootElement.GetRawText() : throw new ArgumentNullException(nameof(doc));
 
-    /// <inheritdoc/>
-    public override string ToString()
+    /// <summary>
+    /// Gets the raw JSON string representation of the field.
+    /// </summary>
+    /// <returns>A string containing the raw JSON data.</returns>
+    public string GetRawValue()
     {
         return _json;
     }

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Fields/JsonSerializedFieldTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Fields/JsonSerializedFieldTests.cs
@@ -119,6 +119,21 @@ public class JsonSerializedFieldTests
         field.Should().BeNull();
     }
 
+    [Fact]
+    public void GetRawValue_ReturnsExpectedJson()
+    {
+        // Arrange
+        const string json = "{\"value\": 100}";
+        JsonDocument token = JsonDocument.Parse(json);
+        JsonSerializedField sut = new(token);
+
+        // Act
+        string result = sut.GetRawValue();
+
+        // Assert
+        result.Should().Be(json);
+    }
+
     private class ValueField<T> : IField
     {
         public required T Value { get; set; }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhacement" as applicable. -->

## Description
This pull request introduces an `GetRawValue()` method in the `JsonSerializedField` class to directly return the raw JSON string. This enhancement provides a more straightforward and efficient way to access the underlying JSON without the need for additional deserialization.

## Motivation
The primary motivation for this change is to simplify the process of working with JSON data, particularly in scenarios where the JSON is deserialized, modified, and then re-serialized. In my case, I needed to deserialize JSON into a `SitecoreLayoutResponseContent` object, apply modifications, and then serialize it back to JSON. Previously, this required a custom `JsonConverter` that accessed the `_json` field via reflection. With this improvement, such workarounds are no longer necessary, making the code cleaner and more maintainable.