### PR TITLE
Handle empty string fields in FieldConverter.

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Converter/FieldConverter.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Converter/FieldConverter.cs
@@ -22,7 +22,7 @@ public class FieldConverter : JsonConverter<IFieldReader>
         JsonDocument doc = JsonDocument.ParseValue(ref reader);
         return doc.RootElement.ValueKind switch
         {
-            JsonValueKind.Object or JsonValueKind.Array => new JsonSerializedField(doc),
+            JsonValueKind.Object or JsonValueKind.Array or JsonValueKind.String => new JsonSerializedField(doc),
             _ => throw new JsonException($"Expected an array or object when deserializing a {typeof(IFieldReader)}. Found {reader.TokenType}"),
         };
     }

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Converter/FieldConverter.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Serialization/Converter/FieldConverter.cs
@@ -22,7 +22,7 @@ public class FieldConverter : JsonConverter<IFieldReader>
         JsonDocument doc = JsonDocument.ParseValue(ref reader);
         return doc.RootElement.ValueKind switch
         {
-            JsonValueKind.Object or JsonValueKind.Array or JsonValueKind.String => new JsonSerializedField(doc),
+            JsonValueKind.Object or JsonValueKind.Array => new JsonSerializedField(doc),
             _ => throw new JsonException($"Expected an array or object when deserializing a {typeof(IFieldReader)}. Found {reader.TokenType}"),
         };
     }

--- a/tests/data/json/headlessSxa.json
+++ b/tests/data/json/headlessSxa.json
@@ -122,6 +122,29 @@
 				],
 				"headless-main": [
 					{
+						"uid": "a1d00efc-5354-4a58-9404-8448c532ad1d",
+						"componentName": "HeadlineBarSection",
+						"dataSource": "/sitecore/content/Test Collection/iva-test/Home/Data/HeadlineBar 1",
+						"params": {
+							"DynamicPlaceholderId": "2",
+							"FieldNames": "Banner",
+							"GridParameters": "col-12"
+						},
+						"fields": {
+							"title": "",
+							"leftLink": {
+								"key": "40dfd6adb1334ff48c3e4c68ab9b9b35",
+								"text": "The Energy Transition",
+								"href": "/connections/energy-transition-and-sustainability/what-is-the-energy-transition"
+							},
+							"rightLink": {
+								"key": "de61e12028784b4da96a9676b73fc764",
+								"text": "There are currently 54 known outages.",
+								"href": "/outages-and-maintenance"
+							}
+						}
+					},
+					{
 						"uid": "86d9c1c9-1c1a-4886-af9f-526d8033df00",
 						"componentName": "RichText",
 						"dataSource": "/sitecore/content/Test Collection/iva-test/Home/Data/Text 1",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhacement" as applicable. -->

## Description
This update addresses a specific issue encountered when dealing with JSON data for fields, such as the following example:
```
"fields": {
    "title": "",
    "leftLink": {
        "key": "40dfd6adb1334ff48c3e4c68ab9b9b35",
        "text": "The Energy Transition",
        "href": "/connections/energy-transition-and-sustainability/what-is-the-energy-transition"
    },
    "rightLink": {
        "key": "de61e12028784b4da96a9676b73fc764",
        "text": "There are currently 54 known outages.",
        "href": "/outages-and-maintenance"
    }
}

```
Previously, an empty string in the `title` field would trigger a `JsonException` in the `FieldConverter` because it was not recognized as a valid `JsonValueKind` type. This update introduces support for `JsonValueKind.String`, ensuring that empty strings are handled correctly alongside objects and arrays, thereby resolving the error.

## Motivation
Custom Content Resolvers in both XM Cloud and Sitecore XP may return empty strings for certain fields, leading to errors in the `FieldConverter`. This enhancement ensures that such cases are handled properly, allowing for smooth operation regardless of whether an empty string is encountered.

**Update:** Following the discussion below, this PR has been revised to focus on adding an integration test for fields with empty strings instead of altering the `FieldConverter`.