### PR TITLE
Pages MetaData Editing Mode Support

### DIFF
--- a/Sitecore.AspNetCore.SDK.sln
+++ b/Sitecore.AspNetCore.SDK.sln
@@ -112,6 +112,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 		.github\ISSUE_TEMPLATE\Question.yml = .github\ISSUE_TEMPLATE\Question.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.AspNetCore.SDK.Pages", "src\Sitecore.AspNetCore.SDK.Pages\Sitecore.AspNetCore.SDK.Pages.csproj", "{F33DC6F7-83F8-41CE-852C-8279D1266139}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +188,10 @@ Global
 		{100C07C6-C68D-469F-9F15-139CB48CB7F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{100C07C6-C68D-469F-9F15-139CB48CB7F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{100C07C6-C68D-469F-9F15-139CB48CB7F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -221,6 +227,7 @@ Global
 		{100C07C6-C68D-469F-9F15-139CB48CB7F0} = {BDE3D3B9-8291-4AE9-B8DA-868CEBCBDC4D}
 		{1706E43D-AC19-4FBB-9BFB-18A8B195580A} = {5FE82369-DEF2-4136-B74F-6E86DB91050E}
 		{24CCC156-046B-4600-9DB0-FC3269A18747} = {5FE82369-DEF2-4136-B74F-6E86DB91050E}
+		{F33DC6F7-83F8-41CE-852C-8279D1266139} = {75482B5D-21E2-4DBE-BE78-657ECF0D409F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E4F7126-B772-42CB-8F90-93B221ED0A72}

--- a/Sitecore.AspNetCore.SDK.sln
+++ b/Sitecore.AspNetCore.SDK.sln
@@ -114,6 +114,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.AspNetCore.SDK.Pages", "src\Sitecore.AspNetCore.SDK.Pages\Sitecore.AspNetCore.SDK.Pages.csproj", "{F33DC6F7-83F8-41CE-852C-8279D1266139}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.AspNetCore.SDK.Pages.Tests", "tests\Sitecore.AspNetCore.SDK.Pages.Tests\Sitecore.AspNetCore.SDK.Pages.Tests.csproj", "{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -192,6 +194,10 @@ Global
 		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F33DC6F7-83F8-41CE-852C-8279D1266139}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -228,6 +234,7 @@ Global
 		{1706E43D-AC19-4FBB-9BFB-18A8B195580A} = {5FE82369-DEF2-4136-B74F-6E86DB91050E}
 		{24CCC156-046B-4600-9DB0-FC3269A18747} = {5FE82369-DEF2-4136-B74F-6E86DB91050E}
 		{F33DC6F7-83F8-41CE-852C-8279D1266139} = {75482B5D-21E2-4DBE-BE78-657ECF0D409F}
+		{55601B5C-5D9C-66E5-801D-E5D5EA0E29D6} = {BDE3D3B9-8291-4AE9-B8DA-868CEBCBDC4D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E4F7126-B772-42CB-8F90-93B221ED0A72}

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Layout Service GraphQL Response.
+/// </summary>
+public class EditingLayoutQueryResponse
+{
+    /// <summary>
+    /// Gets or sets Item for the Editing Layout Response.
+    /// </summary>
+    public ItemModel? Item { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/GraphQlLayoutServiceHandler.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/GraphQlLayoutServiceHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.Metrics;
-using System.Text.Json;
+﻿using System.Text.Json;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -44,116 +43,9 @@ public class GraphQlLayoutServiceHandler(
         }
         else
         {
-            content = IsEditingRequest(request)
-                ? await HandleEditingLayoutRequest(request, requestLanguage, errors, content).ConfigureAwait(false)
-                : await HandleLayoutRequest(request, requestLanguage, errors, content).ConfigureAwait(false);
-        }
-
-        return new SitecoreLayoutResponse(request, errors)
-        {
-            Content = content,
-            Metadata = new Dictionary<string, string>().ToLookup(k => k.Key, v => v.Value)
-        };
-    }
-
-    private static bool IsEditingRequest(SitecoreLayoutRequest request)
-    {
-        if (!request.ContainsKey("sc_request_headers_key") ||
-            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
-            !headers.ContainsKey("mode"))
-        {
-            return false;
-        }
-
-        return headers["mode"].Contains("edit");
-    }
-
-    private async Task<SitecoreLayoutResponseContent?> HandleEditingLayoutRequest(SitecoreLayoutRequest request, string requestLanguage, List<SitecoreLayoutServiceClientException> errors, SitecoreLayoutResponseContent? content)
-    {
-        // TODO: Handle population of Dictionary for large size with extra GQL requests
-        GraphQLRequest layoutRequest = new()
-        {
-            Query = @"
-                    query EditingQuery($siteName: String!, $itemId: String!, $language: String!, $version: String, $after: String, $pageSize: Int = 10) {
-	                    item(path: $itemId, language: $language, version: $version) {
-	                        rendered
-	                    }
-	                    site {
-	                        siteInfo(site: $siteName) {
-	                            dictionary(language: $language, first: $pageSize, after: $after) {
-	                                results {
-					                    key
-	                                    value
-	                                }
-	                                pageInfo {
-	                                  endCursor
-	                                  hasNext
-	                                }
-	                            }
-	                        }
-	                    }
-                    }    
-                    ",
-            OperationName = "EditingQuery",
-            Variables = new
+            GraphQLRequest layoutRequest = new()
             {
-                itemId = GetRequestArgValue(request, "sc_itemid"),
-                language = requestLanguage,
-                siteName = request.SiteName(),
-                version = GetRequestArgValue(request, "sc_version"),
-                pageSize = 50,
-                after = string.Empty
-            }
-        };
-
-        GraphQLResponse<EditingLayoutQueryResponse> response = await _client.SendQueryAsync<EditingLayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
-        if (_logger.IsEnabled(LogLevel.Debug))
-        {
-            _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Item);
-        }
-
-        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
-        string? json = response.Data?.Item?.Rendered.ToString();
-        if (json == null)
-        {
-            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
-        }
-        else
-        {
-            content = _serializer.Deserialize(json);
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
-                _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
-            }
-        }
-
-        if (response.Errors != null)
-        {
-            errors.AddRange(
-                response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
-        }
-
-        return content;
-    }
-
-    private object GetRequestArgValue(SitecoreLayoutRequest request, string argName)
-    {
-        if (!request.ContainsKey("sc_request_headers_key") ||
-            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
-            !headers.ContainsKey(argName))
-        {
-            throw new ArgumentException($"Unable to parse arg:{argName} for Pages MetaData Render request.");
-        }
-
-        return headers[argName].FirstOrDefault() ?? string.Empty;
-    }
-
-    private async Task<SitecoreLayoutResponseContent?> HandleLayoutRequest(SitecoreLayoutRequest request, string requestLanguage, List<SitecoreLayoutServiceClientException> errors, SitecoreLayoutResponseContent? content)
-    {
-        GraphQLRequest layoutRequest = new()
-        {
-            Query = @"
+                Query = @"
                         query LayoutQuery($path: String!, $language: String!, $site: String!) {
                             layout(routePath: $path, language: $language, site: $site) {
                                 item {
@@ -161,43 +53,48 @@ public class GraphQlLayoutServiceHandler(
                                 }
                             }
                         }",
-            OperationName = "LayoutQuery",
-            Variables = new
-            {
-                path = request.Path(),
-                language = requestLanguage,
-                site = request.SiteName()
-            }
-        };
+                OperationName = "LayoutQuery",
+                Variables = new
+                {
+                    path = request.Path(),
+                    language = requestLanguage,
+                    site = request.SiteName()
+                }
+            };
 
-        GraphQLResponse<LayoutQueryResponse> response = await _client.SendQueryAsync<LayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
-        if (_logger.IsEnabled(LogLevel.Debug))
-        {
-            _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Layout);
-        }
-
-        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
-        string? json = response.Data?.Layout?.Item?.Rendered.ToString();
-        if (json == null)
-        {
-            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
-        }
-        else
-        {
-            content = _serializer.Deserialize(json);
+            GraphQLResponse<LayoutQueryResponse> response = await _client.SendQueryAsync<LayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
-                _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
+                _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Layout);
+            }
+
+            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
+            string? json = response.Data?.Layout?.Item?.Rendered.ToString();
+            if (json == null)
+            {
+                errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
+            }
+            else
+            {
+                content = _serializer.Deserialize(json);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
+                    _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
+                }
+            }
+
+            if (response.Errors != null)
+            {
+                errors.AddRange(
+                    response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
             }
         }
 
-        if (response.Errors != null)
+        return new SitecoreLayoutResponse(request, errors)
         {
-            errors.AddRange(
-                response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
-        }
-
-        return content;
+            Content = content,
+            Metadata = new Dictionary<string, string>().ToLookup(k => k.Key, v => v.Value)
+        };
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/GraphQlLayoutServiceHandler.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Request/Handlers/GraphQL/GraphQlLayoutServiceHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics.Metrics;
+using System.Text.Json;
 using GraphQL;
 using GraphQL.Client.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -43,52 +44,9 @@ public class GraphQlLayoutServiceHandler(
         }
         else
         {
-            GraphQLRequest layoutRequest = new()
-            {
-                Query = @"
-                        query LayoutQuery($path: String!, $language: String!, $site: String!) {
-                            layout(routePath: $path, language: $language, site: $site) {
-                                item {
-                                    rendered
-                                }
-                            }
-                        }",
-                OperationName = "LayoutQuery",
-                Variables = new
-                {
-                    path = request.Path(),
-                    language = requestLanguage,
-                    site = request.SiteName()
-                }
-            };
-
-            GraphQLResponse<LayoutQueryResponse> response = await _client.SendQueryAsync<LayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Layout);
-            }
-
-            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
-            string? json = response.Data?.Layout?.Item?.Rendered.ToString();
-            if (json == null)
-            {
-                errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
-            }
-            else
-            {
-                content = _serializer.Deserialize(json);
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
-                    _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
-                }
-            }
-
-            if (response.Errors != null)
-            {
-                errors.AddRange(
-                    response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
-            }
+            content = IsEditingRequest(request)
+                ? await HandleEditingLayoutRequest(request, requestLanguage, errors, content).ConfigureAwait(false)
+                : await HandleLayoutRequest(request, requestLanguage, errors, content).ConfigureAwait(false);
         }
 
         return new SitecoreLayoutResponse(request, errors)
@@ -96,5 +54,150 @@ public class GraphQlLayoutServiceHandler(
             Content = content,
             Metadata = new Dictionary<string, string>().ToLookup(k => k.Key, v => v.Value)
         };
+    }
+
+    private static bool IsEditingRequest(SitecoreLayoutRequest request)
+    {
+        if (!request.ContainsKey("sc_request_headers_key") ||
+            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
+            !headers.ContainsKey("mode"))
+        {
+            return false;
+        }
+
+        return headers["mode"].Contains("edit");
+    }
+
+    private async Task<SitecoreLayoutResponseContent?> HandleEditingLayoutRequest(SitecoreLayoutRequest request, string requestLanguage, List<SitecoreLayoutServiceClientException> errors, SitecoreLayoutResponseContent? content)
+    {
+        // TODO: Handle population of Dictionary for large size with extra GQL requests
+        GraphQLRequest layoutRequest = new()
+        {
+            Query = @"
+                    query EditingQuery($siteName: String!, $itemId: String!, $language: String!, $version: String, $after: String, $pageSize: Int = 10) {
+	                    item(path: $itemId, language: $language, version: $version) {
+	                        rendered
+	                    }
+	                    site {
+	                        siteInfo(site: $siteName) {
+	                            dictionary(language: $language, first: $pageSize, after: $after) {
+	                                results {
+					                    key
+	                                    value
+	                                }
+	                                pageInfo {
+	                                  endCursor
+	                                  hasNext
+	                                }
+	                            }
+	                        }
+	                    }
+                    }    
+                    ",
+            OperationName = "EditingQuery",
+            Variables = new
+            {
+                itemId = GetRequestArgValue(request, "sc_itemid"),
+                language = requestLanguage,
+                siteName = request.SiteName(),
+                version = GetRequestArgValue(request, "sc_version"),
+                pageSize = 50,
+                after = string.Empty
+            }
+        };
+
+        GraphQLResponse<EditingLayoutQueryResponse> response = await _client.SendQueryAsync<EditingLayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Item);
+        }
+
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
+        string? json = response.Data?.Item?.Rendered.ToString();
+        if (json == null)
+        {
+            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
+        }
+        else
+        {
+            content = _serializer.Deserialize(json);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
+                _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
+            }
+        }
+
+        if (response.Errors != null)
+        {
+            errors.AddRange(
+                response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
+        }
+
+        return content;
+    }
+
+    private object GetRequestArgValue(SitecoreLayoutRequest request, string argName)
+    {
+        if (!request.ContainsKey("sc_request_headers_key") ||
+            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
+            !headers.ContainsKey(argName))
+        {
+            throw new ArgumentException($"Unable to parse arg:{argName} for Pages MetaData Render request.");
+        }
+
+        return headers[argName].FirstOrDefault() ?? string.Empty;
+    }
+
+    private async Task<SitecoreLayoutResponseContent?> HandleLayoutRequest(SitecoreLayoutRequest request, string requestLanguage, List<SitecoreLayoutServiceClientException> errors, SitecoreLayoutResponseContent? content)
+    {
+        GraphQLRequest layoutRequest = new()
+        {
+            Query = @"
+                        query LayoutQuery($path: String!, $language: String!, $site: String!) {
+                            layout(routePath: $path, language: $language, site: $site) {
+                                item {
+                                    rendered
+                                }
+                            }
+                        }",
+            OperationName = "LayoutQuery",
+            Variables = new
+            {
+                path = request.Path(),
+                language = requestLanguage,
+                site = request.SiteName()
+            }
+        };
+
+        GraphQLResponse<LayoutQueryResponse> response = await _client.SendQueryAsync<LayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Layout);
+        }
+
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract - Data can be null due to bad implementation of dependency library
+        string? json = response.Data?.Layout?.Item?.Rendered.ToString();
+        if (json == null)
+        {
+            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
+        }
+        else
+        {
+            content = _serializer.Deserialize(json);
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
+                _logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
+            }
+        }
+
+        if (response.Errors != null)
+        {
+            errors.AddRange(
+                response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
+        }
+
+        return content;
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/DataSource.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/DataSource.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+
+/// <summary>
+/// Class used to define an items datasource information.
+/// </summary>
+public class DataSource
+{
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Language.
+    /// </summary>
+    public string Language { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Revision.
+    /// </summary>
+    public string Revision { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Version.
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/EditableField.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/EditableField.cs
@@ -14,4 +14,22 @@ public class EditableField<TValue>
     [DataMember(Name = "editable")]
     [JsonPropertyName("editable")]
     public string EditableMarkup { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or Sets the id of the Field.
+    /// </summary>
+    [DataMember(Name = "Id")]
+    [JsonPropertyName("Id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public EditableChrome? OpeningChrome { get; set; }
+
+    /// <inheritdoc />
+    public EditableChrome? ClosingChrome { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the MetaSata for the Field.
+    /// </summary>
+    public MetaData? MetaData { get; set; }
 }

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/IEditableField.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/IEditableField.cs
@@ -9,4 +9,15 @@ public interface IEditableField : IField
     /// Gets or sets the HTML markup for this <see cref="IField"/> when editing.
     /// </summary>
     public string EditableMarkup { get; set; }
+
+    /// <summary>
+    /// Gets or sets the EditableChrome used to render the opening chrome for this field.
+    /// </summary>
+    public EditableChrome? OpeningChrome { get; set; }
+
+    /// <summary>
+    /// Gets or sets the EditableChrome used to render the closing chrome for this field.
+    /// </summary>
+
+    public EditableChrome? ClosingChrome { get; set; }
 }

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/MetaData.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/MetaData.cs
@@ -1,0 +1,33 @@
+﻿namespace Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+
+/// <summary>
+/// Class used to define an items metadata information.
+/// </summary>
+public class MetaData
+{
+    /// <summary>
+    /// Gets or sets the title.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    ///  Gets or sets the FieldId.
+    /// </summary>
+    public string FieldId { get; set; } = string.Empty;
+
+    /// <summary>
+    ///  Gets or sets the FieldType.
+    /// </summary>
+    public string FieldType { get; set; } = string.Empty;
+
+    /// <summary>
+    ///  Gets or sets the RawValue.
+    /// </summary>
+    public string RawValue { get; set; } = string.Empty;
+
+    /// <summary>
+    ///  Gets or sets the DataSource.
+    /// </summary>
+    public DataSource? DataSource { get; set; }
+
+}

--- a/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/WrappedEditableField.cs
+++ b/src/Sitecore.AspNetCore.SDK.LayoutService.Client/Response/Model/WrappedEditableField.cs
@@ -8,7 +8,7 @@ namespace Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 /// that contains a value that can be edited using wrapped HTML markup.
 /// </summary>
 /// <typeparam name="TValue">The value type.</typeparam>
-public class WrappedEditableField<TValue> : Field<TValue>, IWrappedEditableField
+public class WrappedEditableField<TValue> : EditableField<TValue>, IWrappedEditableField
 {
     /// <inheritdoc />
     [DataMember(Name = "editableFirstPart")]

--- a/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesMarkerService.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesMarkerService.cs
@@ -1,0 +1,6 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Configuration;
+
+/// <summary>
+/// Marker service used to identify when Pages services have been registered.
+/// </summary>
+internal class PagesMarkerService;

--- a/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
@@ -8,25 +8,25 @@ public class PagesOptions
     /// <summary>
     /// Gets or sets the config endpoint for Pages MetaData mode.
     /// </summary>
-    public string ConfigEndpoint { get; set; } = "/api/editing/config";
+    public string? ConfigEndpoint { get; set; } = "/api/editing/config";
 
     /// <summary>
     /// Gets or sets the render endpoint for Pages MetaData mode.
     /// </summary>
-    public string RenderEndpoint { get; set; } = "/api/editing/render";
+    public string? RenderEndpoint { get; set; } = "/api/editing/render";
 
     /// <summary>
     /// Gets or sets the valid editing origin for all editing requests.
     /// </summary>
-    public string ValidEditingOrigin { get; set; } = "https://pages.sitecorecloud.io";
+    public string? ValidEditingOrigin { get; set; } = "https://pages.sitecorecloud.io";
 
     /// <summary>
     /// Gets or sets the valid origins for the head to run under.
     /// </summary>
-    public string ValidOrigins { get; set; } = string.Empty;
+    public string? ValidOrigins { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the Editing Secret.
     /// </summary>
-    public string EditingSecret { get; set; } = string.Empty;
+    public string? EditingSecret { get; set; } = string.Empty;
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Configuration/PagesOptions.cs
@@ -1,0 +1,32 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Configuration;
+
+/// <summary>
+/// The options to configure the Pages middleware.
+/// </summary>
+public class PagesOptions
+{
+    /// <summary>
+    /// Gets or sets the config endpoint for Pages MetaData mode.
+    /// </summary>
+    public string ConfigEndpoint { get; set; } = "/api/editing/config";
+
+    /// <summary>
+    /// Gets or sets the render endpoint for Pages MetaData mode.
+    /// </summary>
+    public string RenderEndpoint { get; set; } = "/api/editing/render";
+
+    /// <summary>
+    /// Gets or sets the valid editing origin for all editing requests.
+    /// </summary>
+    public string ValidEditingOrigin { get; set; } = "https://pages.sitecorecloud.io";
+
+    /// <summary>
+    /// Gets or sets the valid origins for the head to run under.
+    /// </summary>
+    public string ValidOrigins { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Editing Secret.
+    /// </summary>
+    public string EditingSecret { get; set; } = string.Empty;
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Constants.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Constants.cs
@@ -1,0 +1,30 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages
+{
+    /// <summary>
+    /// Class used to stored constants referenced throughout the Pages project.
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        /// Class used to hold the names of different Layout Clients used by the Pages project.
+        /// </summary>
+        public static class LayoutClients
+        {
+            /// <summary>
+            /// Name of the Pages Editing Layout Client.
+            /// </summary>
+            public const string Pages = "pages";
+        }
+
+        /// <summary>
+        /// Class used to hold the names of the different tag helpers defined in the Pages project.
+        /// </summary>
+        public static class SitecoreTagHelpers
+        {
+            /// <summary>
+            /// The HTML tag used to render the Editing Scripts tag helper.
+            /// </summary>
+            public const string EditScriptsHtmlTag = "sc-editingscripts";
+        }
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
 using Sitecore.AspNetCore.SDK.Pages.Configuration;
 using Sitecore.AspNetCore.SDK.Pages.Middleware;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
 
 namespace Sitecore.AspNetCore.SDK.Pages.Extensions;
@@ -53,6 +57,32 @@ public static class PagesAppConfigurationExtensions
             services.Configure(options);
         }
 
+        services.Configure((Action<RenderingEngineOptions>)(renderingOptions =>
+        {
+            renderingOptions.MapToRequest((httpRequest, layoutRequest) =>
+            {
+                MapRequest(httpRequest, layoutRequest, "mode");
+                MapRequest(httpRequest, layoutRequest, "sc_itemid");
+                MapRequest(httpRequest, layoutRequest, "sc_version");
+            });
+        }));
+
         return serviceBuilder;
+    }
+
+    private static void MapRequest(HttpRequest httpRequest, SitecoreLayoutRequest layoutRequest, string paramName)
+    {
+        if (httpRequest.Query == null || !httpRequest.Query.ContainsKey(paramName))
+        {
+            return;
+        }
+
+        string[]? modeQueryValue = httpRequest.Query[paramName];
+        if (modeQueryValue == null)
+        {
+            return;
+        }
+
+        layoutRequest.AddHeader(paramName, modeQueryValue);
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.Middleware;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Extensions;
+
+/// <summary>
+/// Configuration helpers for Pages functionality.
+/// </summary>
+public static class PagesAppConfigurationExtensions
+{
+    /// <summary>
+    /// Registers the Sitecore Experience Editor middleware into the <see cref="IApplicationBuilder"/>.
+    /// </summary>
+    /// <param name="app">The instance of the <see cref="IApplicationBuilder"/> to extend.</param>
+    /// <returns>The <see cref="IApplicationBuilder"/> so that additional calls can be chained.</returns>
+    public static IApplicationBuilder UseSitecorePages(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        object? experienceEditorMarker = app.ApplicationServices.GetService(typeof(PagesMarkerService));
+        if (experienceEditorMarker != null)
+        {
+            app.UseMiddleware<PagesConfigMiddleware>();
+            app.UseMiddleware<PagesRenderMiddleware>();
+        }
+
+        return app;
+    }
+
+    /// <summary>
+    /// Adds the Sitecore Experience Editor support services to the <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <param name="serviceBuilder">The <see cref="ISitecoreRenderingEngineBuilder" /> to add services to.</param>
+    /// <param name="options">Configures the <see cref="PagesOptions" /> options.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static ISitecoreRenderingEngineBuilder WithSitecorePages(this ISitecoreRenderingEngineBuilder serviceBuilder, Action<PagesOptions>? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceBuilder);
+
+        IServiceCollection services = serviceBuilder.Services;
+        if (services.Any(s => s.ServiceType == typeof(PagesMarkerService)))
+        {
+            return serviceBuilder;
+        }
+
+        services.AddSingleton<PagesMarkerService>();
+
+        if (options != null)
+        {
+            services.Configure(options);
+        }
+
+        return serviceBuilder;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Extensions/PagesAppConfigurationExtensions.cs
@@ -1,9 +1,15 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Interfaces;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
 using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.GraphQL;
 using Sitecore.AspNetCore.SDK.Pages.Middleware;
+using Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
@@ -27,7 +33,7 @@ public static class PagesAppConfigurationExtensions
         object? experienceEditorMarker = app.ApplicationServices.GetService(typeof(PagesMarkerService));
         if (experienceEditorMarker != null)
         {
-            app.UseMiddleware<PagesConfigMiddleware>();
+            app.UseMiddleware<PageSetupMiddleware>();
             app.UseMiddleware<PagesRenderMiddleware>();
         }
 
@@ -38,9 +44,10 @@ public static class PagesAppConfigurationExtensions
     /// Adds the Sitecore Experience Editor support services to the <see cref="IServiceCollection" />.
     /// </summary>
     /// <param name="serviceBuilder">The <see cref="ISitecoreRenderingEngineBuilder" /> to add services to.</param>
+    /// <param name="contextId">The ContextId for the environment being used.</param>
     /// <param name="options">Configures the <see cref="PagesOptions" /> options.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-    public static ISitecoreRenderingEngineBuilder WithSitecorePages(this ISitecoreRenderingEngineBuilder serviceBuilder, Action<PagesOptions>? options = null)
+    public static ISitecoreRenderingEngineBuilder WithSitecorePages(this ISitecoreRenderingEngineBuilder serviceBuilder, string contextId, Action<PagesOptions>? options = null)
     {
         ArgumentNullException.ThrowIfNull(serviceBuilder);
 
@@ -51,6 +58,7 @@ public static class PagesAppConfigurationExtensions
         }
 
         services.AddSingleton<PagesMarkerService>();
+        services.AddSingleton<IGraphQLClientFactory>(new GraphQLClientFactory(contextId));
 
         if (options != null)
         {
@@ -64,10 +72,36 @@ public static class PagesAppConfigurationExtensions
                 MapRequest(httpRequest, layoutRequest, "mode");
                 MapRequest(httpRequest, layoutRequest, "sc_itemid");
                 MapRequest(httpRequest, layoutRequest, "sc_version");
+                MapRequest(httpRequest, layoutRequest, "sc_lang");
+                MapRequest(httpRequest, layoutRequest, "sc_site");
+                MapRequest(httpRequest, layoutRequest, "sc_layoutKind");
+                MapRequest(httpRequest, layoutRequest, "secret");
+                MapRequest(httpRequest, layoutRequest, "tenant_id");
+                MapRequest(httpRequest, layoutRequest, "route");
             });
         }));
 
         return serviceBuilder;
+    }
+
+    /// <summary>
+    /// Registers an HTTP request handler for the Sitecore layout service client.
+    /// </summary>
+    /// <param name="builder">The <see cref="ISitecoreLayoutClientBuilder"/> to configure.</param>
+    /// <returns>The <see cref="ILayoutRequestHandlerBuilder{HttpLayoutRequestHandler}"/> so that additional calls can be chained.</returns>
+
+    public static ISitecoreLayoutClientBuilder AddSitecorePagesHandler(
+        this ISitecoreLayoutClientBuilder builder)
+    {
+        string name = Constants.LayoutClients.Pages;
+        builder.AddHandler(name, sp
+            => ActivatorUtilities.CreateInstance<GraphQLEditingServiceHandler>(
+                sp,
+                sp.GetRequiredService<IGraphQLClientFactory>(),
+                sp.GetRequiredService<ISitecoreLayoutSerializer>(),
+                sp.GetRequiredService<ILogger<GraphQLEditingServiceHandler>>()));
+
+        return builder;
     }
 
     private static void MapRequest(HttpRequest httpRequest, SitecoreLayoutRequest layoutRequest, string paramName)

--- a/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
@@ -12,7 +12,7 @@ namespace Sitecore.AspNetCore.SDK.Pages.GraphQL;
 public class GraphQLClientFactory(string contextId)
     : IGraphQLClientFactory
 {
-    private readonly string contextId = contextId;
+    private readonly string contextId = contextId ?? throw new ArgumentNullException(nameof(contextId));
 
     /// <inheritdoc />
     public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, bool editMode)

--- a/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
@@ -15,19 +15,19 @@ public class GraphQLClientFactory(string contextId)
     private readonly string contextId = contextId;
 
     /// <inheritdoc />
-    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, string editMode)
+    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, bool editMode)
     {
         uri ??= new Uri("https://edge-platform.sitecorecloud.io/v1/content/api/graphql/v1");
         uri = uri.AddQueryString("sitecoreContextId", contextId)!;
 
         GraphQLHttpClient client = new(uri, new SystemTextJsonSerializer());
         client.HttpClient.DefaultRequestHeaders.Add("sc_layoutKind", layoutKind);
-        client.HttpClient.DefaultRequestHeaders.Add("sc_editmode", editMode);
+        client.HttpClient.DefaultRequestHeaders.Add("sc_editmode", editMode.ToString());
         return client;
     }
 
     /// <inheritdoc />
-    public IGraphQLClient GenerateClient(string layoutKind, string editMode)
+    public IGraphQLClient GenerateClient(string layoutKind, bool editMode)
     {
         return GenerateClient(null, layoutKind, editMode);
     }

--- a/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/GraphQLClientFactory.cs
@@ -1,0 +1,34 @@
+﻿using GraphQL.Client.Abstractions;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.SystemTextJson;
+using Sitecore.AspNetCore.SDK.GraphQL.Extensions;
+
+namespace Sitecore.AspNetCore.SDK.Pages.GraphQL;
+
+/// <summary>
+/// GraphQLClientFactory used to generate instances of of GraphQLClients authenticated using a ContextId.
+/// <param name="contextId">The contextId for the envionment being used.</param>
+/// </summary>
+public class GraphQLClientFactory(string contextId)
+    : IGraphQLClientFactory
+{
+    private readonly string contextId = contextId;
+
+    /// <inheritdoc />
+    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, string editMode)
+    {
+        uri ??= new Uri("https://edge-platform.sitecorecloud.io/v1/content/api/graphql/v1");
+        uri = uri.AddQueryString("sitecoreContextId", contextId)!;
+
+        GraphQLHttpClient client = new(uri, new SystemTextJsonSerializer());
+        client.HttpClient.DefaultRequestHeaders.Add("sc_layoutKind", layoutKind);
+        client.HttpClient.DefaultRequestHeaders.Add("sc_editmode", editMode);
+        return client;
+    }
+
+    /// <inheritdoc />
+    public IGraphQLClient GenerateClient(string layoutKind, string editMode)
+    {
+        return GenerateClient(null, layoutKind, editMode);
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/IGraphQLClientFactory.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/IGraphQLClientFactory.cs
@@ -1,0 +1,26 @@
+﻿using GraphQL.Client.Abstractions;
+
+namespace Sitecore.AspNetCore.SDK.Pages.GraphQL;
+
+/// <summary>
+/// Interface used to define the contract that IGraphQlClientFactories need to adhere to.
+/// </summary>
+public interface IGraphQLClientFactory
+{
+    /// <summary>
+    /// Method used to generate an instance of <see cref="IGraphQLClient" />.
+    /// </summary>
+    /// <param name="uri">GraphQl endpoint uri.</param>
+    /// <param name="layoutKind">The layout type for this request, shared or final.</param>
+    /// <param name="editMode">The edit mode version for this client.</param>
+    /// <returns>Concrete implementation of <see cref="IGraphQLClient" /> interface.</returns>
+    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, string editMode);
+
+    /// <summary>
+    /// Method used to generate an instance of <see cref="IGraphQLClient" />.
+    /// </summary>
+    /// <param name="layoutKind">The layout type for this request, shared or final.</param>
+    /// <param name="editMode">The edit mode version for this client.</param>
+    /// <returns>Concrete implementation of <see cref="IGraphQLClient" /> interface.</returns>
+    public IGraphQLClient GenerateClient(string layoutKind, string editMode);
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/IGraphQLClientFactory.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/GraphQL/IGraphQLClientFactory.cs
@@ -14,7 +14,7 @@ public interface IGraphQLClientFactory
     /// <param name="layoutKind">The layout type for this request, shared or final.</param>
     /// <param name="editMode">The edit mode version for this client.</param>
     /// <returns>Concrete implementation of <see cref="IGraphQLClient" /> interface.</returns>
-    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, string editMode);
+    public IGraphQLClient GenerateClient(Uri? uri, string layoutKind, bool editMode);
 
     /// <summary>
     /// Method used to generate an instance of <see cref="IGraphQLClient" />.
@@ -22,5 +22,5 @@ public interface IGraphQLClientFactory
     /// <param name="layoutKind">The layout type for this request, shared or final.</param>
     /// <param name="editMode">The edit mode version for this client.</param>
     /// <returns>Concrete implementation of <see cref="IGraphQLClient" /> interface.</returns>
-    public IGraphQLClient GenerateClient(string layoutKind, string editMode);
+    public IGraphQLClient GenerateClient(string layoutKind, bool editMode);
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PageSetupMiddleware.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PageSetupMiddleware.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.Models;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
 
 namespace Sitecore.AspNetCore.SDK.Pages.Middleware;
@@ -12,17 +13,17 @@ namespace Sitecore.AspNetCore.SDK.Pages.Middleware;
 /// and wraps the response HTML in a JSON format.
 /// </summary>
 /// <remarks>
-/// Initializes a new instance of the <see cref="PagesConfigMiddleware"/> class.
+/// Initializes a new instance of the <see cref="PageSetupMiddleware"/> class.
 /// </remarks>
 /// <param name="next">The next middleware to call.</param>
 /// <param name="options">The Sitecore Pages configuration options.</param>
 /// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
 /// <param name="renderingEngineOptions">The RenderingEngineOptions, used to retriece a list of all registered renderings for the applications</param>
-public class PagesConfigMiddleware(RequestDelegate next, IOptions<PagesOptions> options, ILogger<PagesConfigMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+public class PageSetupMiddleware(RequestDelegate next, IOptions<PagesOptions> options, ILogger<PageSetupMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
 {
     private readonly RequestDelegate next = next ?? throw new ArgumentNullException(nameof(next));
     private readonly PagesOptions options = options != null ? options.Value : throw new ArgumentNullException(nameof(options));
-    private readonly ILogger<PagesConfigMiddleware> logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly ILogger<PageSetupMiddleware> logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly RenderingEngineOptions renderingEngineOptions = renderingEngineOptions != null ? renderingEngineOptions.Value : throw new ArgumentNullException(nameof(renderingEngineOptions));
 
     /// <summary>
@@ -39,7 +40,55 @@ public class PagesConfigMiddleware(RequestDelegate next, IOptions<PagesOptions> 
             return;
         }
 
+        if (IsValidPagesRenderRequest(httpContext.Request))
+        {
+            logger.LogDebug("Processing valid Pages Render request");
+
+            PerformPagesRedirect(httpContext, ParseQueryStringArgs(httpContext.Request));
+
+            return;
+        }
+
         await next(httpContext).ConfigureAwait(false);
+    }
+
+    private void PerformPagesRedirect(HttpContext httpContext, PagesRenderArgs args)
+    {
+        httpContext.Response.Headers.ContentSecurityPolicy = $"frame-ancestors 'self' {options.ValidOrigins} {options.ValidEditingOrigin}";
+        httpContext.Response.Redirect($"{args.Route}?mode={args.Mode}&sc_itemid={args.ItemId}&sc_version={args.Version}&sc_lang={args.Language}&sc_site={args.Site}&sc_layoutKind={args.LayoutKind}&secret={args.EditingSecret}&tenant_id={args.TenantId}&route={args.Route}", permanent: false);
+    }
+
+    private bool IsValidPagesRenderRequest(HttpRequest httpRequest)
+    {
+        ArgumentNullException.ThrowIfNull(httpRequest);
+        if (httpRequest.Method != HttpMethods.Get || !httpRequest.Path.Value!.Equals(options.RenderEndpoint, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!IsValidEditingSecret(httpRequest))
+        {
+            logger.LogError("Invalid Pages Editing Secret Value");
+            return false;
+        }
+
+        return true;
+    }
+
+    private PagesRenderArgs ParseQueryStringArgs(HttpRequest request)
+    {
+        return new PagesRenderArgs
+        {
+            ItemId = Guid.TryParse(request.Query["sc_itemid"].FirstOrDefault(), out Guid itemId) ? itemId : Guid.Empty,
+            EditingSecret = request.Query["secret"].FirstOrDefault() ?? string.Empty,
+            Language = request.Query["sc_lang"].FirstOrDefault() ?? string.Empty,
+            LayoutKind = request.Query["sc_layoutKind"].FirstOrDefault() ?? string.Empty,
+            Mode = request.Query["mode"].FirstOrDefault() ?? string.Empty,
+            Route = request.Query["route"].FirstOrDefault() ?? string.Empty,
+            Site = request.Query["sc_site"].FirstOrDefault() ?? string.Empty,
+            Version = int.TryParse(request.Query["sc_version"].FirstOrDefault(), out int version) ? version : 0,
+            TenantId = request.Query["tenant_id"].FirstOrDefault() ?? string.Empty,
+        };
     }
 
     private async Task BuildResponse(HttpResponse httpResponse)

--- a/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PageSetupMiddleware.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PageSetupMiddleware.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Primitives;
 using Sitecore.AspNetCore.SDK.Pages.Configuration;
 using Sitecore.AspNetCore.SDK.Pages.Models;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 
 namespace Sitecore.AspNetCore.SDK.Pages.Middleware;
 
@@ -100,39 +101,16 @@ public class PageSetupMiddleware(RequestDelegate next, IOptions<PagesOptions> op
         httpResponse.StatusCode = StatusCodes.Status200OK;
         httpResponse.ContentType = "application/json";
 
-        // TODO: change the Components list to not be hardcoded!
-        string responseBody = @"
-            {
+        string componentNames = string.Join(",\r\n", renderingEngineOptions.RendererRegistry.Select(x => $"\"{x.Value.ComponentName}\""));
+        string responseBody = $@"
+            {{
                 ""components"": [
-                    ""Title"",
-                    ""Container"",
-                    ""ColumnSplitter"",
-                    ""RowSplitter"",
-                    ""PageContent"",
-                    ""RichText"",
-                    ""Promo"",
-                    ""LinkList"",
-                    ""Image"",
-                    ""PartialDesignDynamicPlaceholder"",
-                    ""Navigation""
+                    {componentNames}
                 ],
-                ""packages"": {
-                    ""@sitecore/byoc"": ""0.2.15"",
-                    ""@sitecore/components"": ""1.1.10"",
-                    ""@sitecore/engage"": ""1.4.3"",
-                    ""@sitecore-cloudsdk/core"": ""0.3.1"",
-                    ""@sitecore-cloudsdk/events"": ""0.3.1"",
-                    ""@sitecore-cloudsdk/personalize"": ""0.3.1"",
-                    ""@sitecore-cloudsdk/utils"": ""0.3.1"",
-                    ""@sitecore-feaas/clientside"": ""0.5.18"",
-                    ""@sitecore-jss/sitecore-jss"": ""22.1.3"",
-                    ""@sitecore-jss/sitecore-jss-cli"": ""22.1.3"",
-                    ""@sitecore-jss/sitecore-jss-dev-tools"": ""22.1.3"",
-                    ""@sitecore-jss/sitecore-jss-nextjs"": ""22.1.3"",
-                    ""@sitecore-jss/sitecore-jss-react"": ""22.1.3""
-                },
+                ""packages"": {{
+                }},
                 ""editMode"": ""metadata""
-            }
+            }}
         ";
 
         await httpResponse.WriteAsync(responseBody);

--- a/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesConfigMiddleware.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesConfigMiddleware.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Middleware;
+
+/// <summary>
+/// The Pages middleware implementation that handles GET requests from the Sitecore Pages in MetaData Editing mode
+/// and wraps the response HTML in a JSON format.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="PagesConfigMiddleware"/> class.
+/// </remarks>
+/// <param name="next">The next middleware to call.</param>
+/// <param name="options">The Sitecore Pages configuration options.</param>
+/// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
+/// <param name="renderingEngineOptions">The RenderingEngineOptions, used to retriece a list of all registered renderings for the applications</param>
+public class PagesConfigMiddleware(RequestDelegate next, IOptions<PagesOptions> options, ILogger<PagesConfigMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+{
+    private readonly RequestDelegate next = next ?? throw new ArgumentNullException(nameof(next));
+    private readonly PagesOptions options = options != null ? options.Value : throw new ArgumentNullException(nameof(options));
+    private readonly ILogger<PagesConfigMiddleware> logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly RenderingEngineOptions renderingEngineOptions = renderingEngineOptions != null ? renderingEngineOptions.Value : throw new ArgumentNullException(nameof(renderingEngineOptions));
+
+    /// <summary>
+    /// The middleware Invoke method.
+    /// </summary>
+    /// <param name="httpContext">The current <see cref="HttpContext"/>.</param>
+    /// <returns>A Task to support async calls.</returns>
+    public async Task Invoke(HttpContext httpContext)
+    {
+        if (IsValidPagesConfigRequest(httpContext.Request))
+        {
+            logger.LogDebug("Processing valid Pages Config request");
+            await BuildResponse(httpContext.Response);
+            return;
+        }
+
+        await next(httpContext).ConfigureAwait(false);
+    }
+
+    private async Task BuildResponse(HttpResponse httpResponse)
+    {
+        httpResponse.Headers.ContentSecurityPolicy = $"frame-ancestors 'self' {options.ValidOrigins} {options.ValidEditingOrigin}";
+        httpResponse.Headers.AccessControlAllowOrigin = options.ValidEditingOrigin;
+        httpResponse.Headers.AccessControlAllowMethods = "GET, POST, OPTIONS, PUT, PATCH, DELETE";
+
+        httpResponse.StatusCode = StatusCodes.Status200OK;
+        httpResponse.ContentType = "application/json";
+
+        // TODO: change the Components list to not be hardcoded!
+        string responseBody = @"
+            {
+                ""components"": [
+                    ""Title"",
+                    ""Container"",
+                    ""ColumnSplitter"",
+                    ""RowSplitter"",
+                    ""PageContent"",
+                    ""RichText"",
+                    ""Promo"",
+                    ""LinkList"",
+                    ""Image"",
+                    ""PartialDesignDynamicPlaceholder"",
+                    ""Navigation""
+                ],
+                ""packages"": {
+                    ""@sitecore/byoc"": ""0.2.15"",
+                    ""@sitecore/components"": ""1.1.10"",
+                    ""@sitecore/engage"": ""1.4.3"",
+                    ""@sitecore-cloudsdk/core"": ""0.3.1"",
+                    ""@sitecore-cloudsdk/events"": ""0.3.1"",
+                    ""@sitecore-cloudsdk/personalize"": ""0.3.1"",
+                    ""@sitecore-cloudsdk/utils"": ""0.3.1"",
+                    ""@sitecore-feaas/clientside"": ""0.5.18"",
+                    ""@sitecore-jss/sitecore-jss"": ""22.1.3"",
+                    ""@sitecore-jss/sitecore-jss-cli"": ""22.1.3"",
+                    ""@sitecore-jss/sitecore-jss-dev-tools"": ""22.1.3"",
+                    ""@sitecore-jss/sitecore-jss-nextjs"": ""22.1.3"",
+                    ""@sitecore-jss/sitecore-jss-react"": ""22.1.3""
+                },
+                ""editMode"": ""metadata""
+            }
+        ";
+
+        await httpResponse.WriteAsync(responseBody);
+    }
+
+    private bool IsValidEditingSecret(HttpRequest httpRequest)
+    {
+        if (httpRequest.Query.TryGetValue("secret", out StringValues editingSecretValues))
+        {
+            string editingSecret = editingSecretValues.FirstOrDefault() ?? string.Empty;
+            if (editingSecret == options.EditingSecret)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool RequestHasValidEditingOrigin(HttpRequest httpRequest)
+    {
+        if (httpRequest.Headers.Origin == options.ValidEditingOrigin)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsValidPagesConfigRequest(HttpRequest httpRequest)
+    {
+        ArgumentNullException.ThrowIfNull(httpRequest);
+        if (httpRequest.Method != HttpMethods.Get || !httpRequest.Path.Value!.Equals(options.ConfigEndpoint, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!IsValidEditingSecret(httpRequest))
+        {
+            logger.LogError("Invalid Pages Editing Secret Value");
+            return false;
+        }
+
+        if (!RequestHasValidEditingOrigin(httpRequest))
+        {
+            logger.LogError("Invalid Pages Editing Origin");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesRenderMiddleware.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesRenderMiddleware.cs
@@ -44,7 +44,7 @@ public class PagesRenderMiddleware(RequestDelegate next, IOptions<PagesOptions> 
 
     private void PerformPagesRedirect(HttpContext httpContext, PagesRenderArgs args)
     {
-        httpContext.Response.Redirect(args.Route, permanent: false);
+        httpContext.Response.Redirect($"{args.Route}?mode={args.Mode}&sc_itemid={args.ItemId}&sc_version={args.Version}", permanent: false);
     }
 
     private PagesRenderArgs ParseQueryStringArgs(HttpRequest request)

--- a/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesRenderMiddleware.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Middleware/PagesRenderMiddleware.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.Models;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Middleware;
+
+/// <summary>
+/// The Pages middleware implementation that handles GET requests from the Sitecore Pages in MetaData Editing mode
+/// and wraps the response HTML in a JSON format.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="PagesConfigMiddleware"/> class.
+/// </remarks>
+/// <param name="next">The next middleware to call.</param>
+/// <param name="options">The Sitecore Pages configuration options.</param>
+/// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
+public class PagesRenderMiddleware(RequestDelegate next, IOptions<PagesOptions> options, ILogger<PagesConfigMiddleware> logger)
+{
+    private readonly RequestDelegate next = next ?? throw new ArgumentNullException(nameof(next));
+    private readonly PagesOptions options = options != null ? options.Value : throw new ArgumentNullException(nameof(options));
+    private readonly ILogger<PagesConfigMiddleware> logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// The middleware Invoke method.
+    /// </summary>
+    /// <param name="httpContext">The current <see cref="HttpContext"/>.</param>
+    /// <returns>A Task to support async calls.</returns>
+    public async Task Invoke(HttpContext httpContext)
+    {
+        if (IsValidPagesRenderRequest(httpContext.Request))
+        {
+            logger.LogDebug("Processing valid Pages Render request");
+
+            PerformPagesRedirect(httpContext, ParseQueryStringArgs(httpContext.Request));
+
+            return;
+        }
+
+        await next(httpContext).ConfigureAwait(false);
+    }
+
+    private void PerformPagesRedirect(HttpContext httpContext, PagesRenderArgs args)
+    {
+        httpContext.Response.Redirect(args.Route, permanent: false);
+    }
+
+    private PagesRenderArgs ParseQueryStringArgs(HttpRequest request)
+    {
+        return new PagesRenderArgs
+        {
+            ItemId = Guid.TryParse(request.Query["sc_itemid"].FirstOrDefault(), out Guid itemId) ? itemId : Guid.Empty,
+            EditingSecret = request.Query["secret"].FirstOrDefault() ?? string.Empty,
+            Language = request.Query["sc_lang"].FirstOrDefault() ?? string.Empty,
+            LayoutKind = request.Query["sc_layoutKind"].FirstOrDefault() ?? string.Empty,
+            Mode = request.Query["mode"].FirstOrDefault() ?? string.Empty,
+            Route = request.Query["route"].FirstOrDefault() ?? string.Empty,
+            Site = request.Query["sc_site"].FirstOrDefault() ?? string.Empty,
+            Version = int.TryParse(request.Query["sc_version"].FirstOrDefault(), out int version) ? version : 0
+        };
+    }
+
+
+    private bool IsValidEditingSecret(HttpRequest httpRequest)
+    {
+        if (httpRequest.Query.TryGetValue("secret", out StringValues editingSecretValues))
+        {
+            string editingSecret = editingSecretValues.FirstOrDefault() ?? string.Empty;
+            if (editingSecret == options.EditingSecret)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool IsValidPagesRenderRequest(HttpRequest httpRequest)
+    {
+        ArgumentNullException.ThrowIfNull(httpRequest);
+        if (httpRequest.Method != HttpMethods.Get || !httpRequest.Path.Value!.Equals(options.RenderEndpoint, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!IsValidEditingSecret(httpRequest))
+        {
+            logger.LogError("Invalid Pages Editing Secret Value");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Models/PagesRenderArgs.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Models/PagesRenderArgs.cs
@@ -1,0 +1,50 @@
+﻿using GraphQL;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Models
+{
+    /// <summary>
+    /// The model used to store the args passed in to the Render route when using Pages MetaData Editing mode.
+    /// </summary>
+    public class PagesRenderArgs
+    {
+        /// <summary>
+        /// Gets or sets the Id of the item being edited.
+        /// </summary>
+        public Guid ItemId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lanugage of the item being edited.
+        /// </summary>
+        public string Language { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the name of the site being edited.
+        /// </summary>
+        public string Site { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the Version of the item being edited.
+        /// </summary>
+        public int Version { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the Layout kind of item being edited.
+        /// </summary>
+        public string LayoutKind { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the mode that the redering is running.
+        /// </summary>
+        public string Mode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the Editing Secret.
+        /// </summary>
+        public string EditingSecret { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the route to the item within the site.
+        /// </summary>
+        public string Route { get; set; } = string.Empty;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Models/PagesRenderArgs.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Models/PagesRenderArgs.cs
@@ -46,5 +46,10 @@ namespace Sitecore.AspNetCore.SDK.Pages.Models
         /// Gets or sets the route to the item within the site.
         /// </summary>
         public string Route { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the ID of the tenant that editing is being used on.
+        /// </summary>
+        public string TenantId { get; set; } = string.Empty;
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingDictionaryResponse.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingDictionaryResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents a Sitecore sites dictionary collection response.
+/// </summary>
+public class EditingDictionaryResponse
+{
+    /// <summary>
+    /// Gets or sets the Site for the Editing Layout Response.
+    /// </summary>
+    public Site? Site { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
@@ -1,4 +1,5 @@
-﻿using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+﻿using Microsoft.AspNetCore.Mvc.Formatters;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
 
 namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
 
@@ -11,4 +12,9 @@ public class EditingLayoutQueryResponse
     /// Gets or sets Item for the Editing Layout Response.
     /// </summary>
     public ItemModel? Item { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Site for the Editing Layout Response.
+    /// </summary>
+    public Site? Site { get; set; }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/EditingLayoutQueryResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+﻿using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
 
 /// <summary>
 /// Layout Service GraphQL Response.

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/GraphQLEditingServiceHandler.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/GraphQLEditingServiceHandler.cs
@@ -1,0 +1,156 @@
+﻿using System.Text.Json;
+using GraphQL;
+using GraphQL.Client.Abstractions;
+using Microsoft.Extensions.Logging;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Interfaces;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
+using Sitecore.AspNetCore.SDK.Pages.GraphQL;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <inheritdoc cref="ILayoutRequestHandler" />
+/// <summary>
+/// Initializes a new instance of the <see cref="GraphQLEditingServiceHandler"/> class.
+/// </summary>
+/// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
+/// <param name="clientFactory">The GraphQlClientFactory used to generate instances of the GraphQl client.</param>
+/// <param name="serializer">The serializer to handle response data.</param>
+public class GraphQLEditingServiceHandler(IGraphQLClientFactory clientFactory,
+    ISitecoreLayoutSerializer serializer,
+    ILogger<GraphQLEditingServiceHandler> logger)
+    : ILayoutRequestHandler
+{
+    private readonly IGraphQLClientFactory clientFactory = clientFactory;
+    private readonly ISitecoreLayoutSerializer serializer = serializer;
+    private readonly ILogger<GraphQLEditingServiceHandler> logger = logger;
+
+    /// <inheritdoc />
+    public async Task<SitecoreLayoutResponse> Request(SitecoreLayoutRequest request, string handlerName)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(handlerName);
+
+        if (!IsEditingRequest(request))
+        {
+            throw new ArgumentException("GraphQLEditingServiceHandler: Error attempting to process non-editing request");
+        }
+
+        List<SitecoreLayoutServiceClientException> errors = [];
+        SitecoreLayoutResponseContent? content = null;
+
+        string? requestLanguage = request.Language();
+
+        if (string.IsNullOrWhiteSpace(requestLanguage))
+        {
+            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
+        }
+        else
+        {
+            content = await HandleEditingLayoutRequest(request, requestLanguage, errors);
+        }
+
+        return new SitecoreLayoutResponse(request, errors)
+        {
+            Content = content,
+            Metadata = new Dictionary<string, string>().ToLookup(k => k.Key, v => v.Value)
+        };
+    }
+
+    private static bool IsEditingRequest(SitecoreLayoutRequest request)
+    {
+        if (!request.ContainsKey("sc_request_headers_key") ||
+            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
+            !headers.ContainsKey("mode"))
+        {
+            return false;
+        }
+
+        return headers["mode"].Contains("edit");
+    }
+
+    private async Task<SitecoreLayoutResponseContent?> HandleEditingLayoutRequest(SitecoreLayoutRequest request, string requestLanguage, List<SitecoreLayoutServiceClientException> errors)
+    {
+        GraphQLRequest layoutRequest = new()
+        {
+            Query = @"
+                    query EditingQuery($siteName: String!, $itemId: String!, $language: String!, $version: String, $after: String, $pageSize: Int = 10) {
+                     item(path: $itemId, language: $language, version: $version) {
+                         rendered
+                     }
+                     site {
+                         siteInfo(site: $siteName) {
+                             dictionary(language: $language, first: $pageSize, after: $after) {
+                                 results {
+    	                    key
+                                     value
+                                 }
+                                 pageInfo {
+                                   endCursor
+                                   hasNext
+                                 }
+                             }
+                         }
+                     }
+                    }    
+                    ",
+            OperationName = "EditingQuery",
+            Variables = new
+            {
+                itemId = GetRequestArgValue(request, "sc_itemid"),
+                language = requestLanguage,
+                siteName = request.SiteName(),
+                version = GetRequestArgValue(request, "sc_version"),
+                pageSize = 50,
+                after = string.Empty
+            }
+        };
+
+        IGraphQLClient client = clientFactory.GenerateClient(GetRequestArgValue(request, "sc_layoutKind"), GetRequestArgValue(request, "mode"));
+        GraphQLResponse<EditingLayoutQueryResponse> response = await client.SendQueryAsync<EditingLayoutQueryResponse>(layoutRequest).ConfigureAwait(false);
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug("Layout Service GraphQL Response : {responseDataLayout}", response.Data.Item);
+        }
+
+        SitecoreLayoutResponseContent? content = null;
+        string? json = response.Data?.Item?.Rendered.ToString();
+        if (json == null)
+        {
+            errors.Add(new ItemNotFoundSitecoreLayoutServiceClientException());
+        }
+        else
+        {
+            content = serializer.Deserialize(json);
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                object? formattedDeserializeObject = JsonSerializer.Deserialize<object?>(json);
+                logger.LogDebug("Layout Service Response JSON : {formattedDeserializeObject}", formattedDeserializeObject);
+            }
+        }
+
+        if (response.Errors != null)
+        {
+            errors.AddRange(
+                response.Errors.Select(e => new SitecoreLayoutServiceClientException(new LayoutServiceGraphQlException(e))));
+        }
+
+        return content;
+    }
+
+    private string GetRequestArgValue(SitecoreLayoutRequest request, string argName)
+    {
+        if (!request.ContainsKey("sc_request_headers_key") ||
+            request["sc_request_headers_key"] is not Dictionary<string, string[]> headers ||
+            !headers.ContainsKey(argName))
+        {
+            throw new ArgumentException($"Unable to parse arg:{argName} for Pages MetaData Render request.");
+        }
+
+        return headers[argName].FirstOrDefault() ?? string.Empty;
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/GraphQLEditingServiceHandler.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/GraphQLEditingServiceHandler.cs
@@ -26,9 +26,9 @@ public class GraphQLEditingServiceHandler(IGraphQLClientFactory clientFactory,
     ILogger<GraphQLEditingServiceHandler> logger)
     : ILayoutRequestHandler
 {
-    private readonly IGraphQLClientFactory clientFactory = clientFactory;
-    private readonly ISitecoreLayoutSerializer serializer = serializer;
-    private readonly ILogger<GraphQLEditingServiceHandler> logger = logger;
+    private readonly IGraphQLClientFactory clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+    private readonly ISitecoreLayoutSerializer serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+    private readonly ILogger<GraphQLEditingServiceHandler> logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc />
     public async Task<SitecoreLayoutResponse> Request(SitecoreLayoutRequest request, string handlerName)

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/PageInfo.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/PageInfo.cs
@@ -1,0 +1,17 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents the page info for a Sitecore site.
+/// </summary>
+public class PageInfo
+{
+    /// <summary>
+    /// Gets or sets the start cursor.
+    /// </summary>
+    public string EndCursor { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether there are more records to be retrieved.
+    /// </summary>
+    public bool HasNext { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/Site.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/Site.cs
@@ -1,0 +1,12 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents a Sitecore site.
+/// </summary>
+public class Site
+{
+    /// <summary>
+    /// Gets or sets the site info.
+    /// </summary>
+    public SiteInfo? SiteInfo { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfo.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfo.cs
@@ -1,0 +1,12 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents the info for a Sitecore site.
+/// </summary>
+public class SiteInfo
+{
+    /// <summary>
+    /// Gets or sets the dictionary for a Sitecore Site.
+    /// </summary>
+    public SiteInfoDictionary? Dictionary { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfoDictionary.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfoDictionary.cs
@@ -1,0 +1,17 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents the dictionary for a Sitecore site.
+/// </summary>
+public class SiteInfoDictionary
+{
+    /// <summary>
+    /// Gets or sets collection of dictionary items for a Sitecore Site.
+    /// </summary>
+    public List<SiteInfoDictionaryItem> Results { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the PageInfo for the Sitecore Site.
+    /// </summary>
+    public PageInfo? PageInfo { get; set;  }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfoDictionaryItem.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Request/Handlers/GraphQL/SiteInfoDictionaryItem.cs
@@ -1,0 +1,17 @@
+﻿namespace Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+
+/// <summary>
+/// Represents a dictionary item for a Sitecore site.
+/// </summary>
+public class SiteInfoDictionaryItem
+{
+    /// <summary>
+    /// Gets or sets the key for the dictionary item.
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the value for the dictionary item.
+    /// </summary>
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Response/CanvasState.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Response/CanvasState.cs
@@ -1,0 +1,51 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Response;
+
+/// <summary>
+/// Class used to store the ClientData editing context, used to enable Pages functionality.
+/// </summary>
+public class CanvasState
+{
+    /// <summary>
+    /// Gets or sets the Id of the item being edited.
+    /// </summary>
+    [JsonPropertyName("itemId")]
+    public string? ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Version of the item being edited.
+    /// </summary>
+    [JsonPropertyName("itemVersion")]
+    public int? ItemVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the site being edited.
+    /// </summary>
+    [JsonPropertyName("siteName")]
+    public string? SiteName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language of the item being edited.
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Id of the Device being edited.
+    /// </summary>
+    [JsonPropertyName("deviceId")]
+    public string? DeviceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current page mode.
+    /// </summary>
+    [JsonPropertyName("pageMode")]
+    public string? PageMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current id of the Varient being edited.
+    /// </summary>
+    [JsonPropertyName("varient")]
+    public string? Varient { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Response/CanvasState.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Response/CanvasState.cs
@@ -46,6 +46,6 @@ public class CanvasState
     /// <summary>
     /// Gets or sets the current id of the Varient being edited.
     /// </summary>
-    [JsonPropertyName("varient")]
-    public string? Varient { get; set; }
+    [JsonPropertyName("variant")]
+    public string? Variant { get; set; }
 }

--- a/src/Sitecore.AspNetCore.SDK.Pages/Response/ClientData.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Response/ClientData.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Response;
+
+/// <summary>
+/// Class used to store the ClientData editing context, used to enable Pages functionality.
+/// </summary>
+public class ClientData
+{
+    /// <summary>
+    /// Gets or sets the Canvas State data of the Editing Request
+    /// </summary>
+    [JsonPropertyName("hrz-canvas-state")]
+    public CanvasState? CanvasState { get; set; }
+
+    /// <summary>
+    /// Gets or sets the verification token used by the Pages canvas.
+    /// </summary>
+    [JsonPropertyName("hrz-canvas-verification-token")]
+    public string? CanvasVerificationToken { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Response/EditingContext.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Response/EditingContext.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Response;
+
+/// <summary>
+/// Class used to extend the standard Sitecore Context with editing specific context data.
+/// </summary>
+public class EditingContext : Context
+{
+    /// <summary>
+    /// Gets or sets the Client data property used to hold the editing specific client data.
+    /// </summary>
+    [JsonPropertyName("clientData")]
+    public ClientData? ClientData { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ClientScripts property used to store the scripts that need to be included in the client app for Pages to function.
+    /// </summary>
+    [JsonPropertyName("clientScripts")]
+    public string[]? ClientScripts { get; set; }
+}

--- a/src/Sitecore.AspNetCore.SDK.Pages/Sitecore.AspNetCore.SDK.Pages.csproj
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Sitecore.AspNetCore.SDK.Pages.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Sitecore.AspNetCore.SDK.LayoutService.Client\Sitecore.AspNetCore.SDK.LayoutService.Client.csproj" />
     <ProjectReference Include="..\Sitecore.AspNetCore.SDK.RenderingEngine\Sitecore.AspNetCore.SDK.RenderingEngine.csproj" />
   </ItemGroup>
 

--- a/src/Sitecore.AspNetCore.SDK.Pages/Sitecore.AspNetCore.SDK.Pages.csproj
+++ b/src/Sitecore.AspNetCore.SDK.Pages/Sitecore.AspNetCore.SDK.Pages.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sitecore.AspNetCore.SDK.RenderingEngine\Sitecore.AspNetCore.SDK.RenderingEngine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
@@ -1,10 +1,8 @@
-﻿using System.Resources;
-using System.Text.Json;
+﻿using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.Pages.Response;
-using Sitecore.AspNetCore.SDK.RenderingEngine;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
 
@@ -34,16 +32,10 @@ namespace Sitecore.AspNetCore.SDK.Pages.TagHelpers
 
             if (renderingContext?.Response?.Content?.Sitecore?.Context?.IsEditing ?? false)
             {
-                JsonDocument doc = JsonDocument.Parse(renderingContext?.Response?.Content.ContextRawData ?? string.Empty);
-                if (doc == null)
-                {
-                    throw new NullReferenceException("EditingScriptsTagHelper: Unable to process ContextRawData");
-                }
-
                 EditingContext? editingContext = JsonSerializer.Deserialize<EditingContext>(renderingContext?.Response?.Content.ContextRawData ?? string.Empty);
                 if (editingContext == null)
                 {
-                    return;
+                    throw new NullReferenceException("EditingScriptsTagHelper: Unable to process ContextRawData");
                 }
 
                 foreach (string script in editingContext.ClientScripts ?? [])
@@ -60,7 +52,7 @@ namespace Sitecore.AspNetCore.SDK.Pages.TagHelpers
                                     ""language"":""{editingContext?.ClientData?.CanvasState?.Language}"",
                                     ""deviceId"":""{editingContext?.ClientData?.CanvasState?.DeviceId}"",
                                     ""pageMode"":""{editingContext?.ClientData?.CanvasState?.PageMode}"",
-                                    ""variant"":""{editingContext?.ClientData?.CanvasState?.Varient}""
+                                    ""variant"":""{editingContext?.ClientData?.CanvasState?.Variant}""
                                 }}
                             </script>
                         ";

--- a/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
@@ -1,0 +1,74 @@
+﻿using System.Resources;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Sitecore.AspNetCore.SDK.Pages.Response;
+using Sitecore.AspNetCore.SDK.RenderingEngine;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
+
+namespace Sitecore.AspNetCore.SDK.Pages.TagHelpers
+{
+    /// <summary>
+    /// EditingScriptsTagHelper, used to output the script tags into the page header when running in Chromes editing mode.
+    /// </summary>
+    [HtmlTargetElement(Constants.SitecoreTagHelpers.EditScriptsHtmlTag)]
+    public class EditingScriptsTagHelper : TagHelper
+    {
+        /// <summary>
+        /// Gets or sets the current view context for the tag helper.
+        /// </summary>
+        [HtmlAttributeNotBound]
+        [ViewContext]
+        public ViewContext? ViewContext { get; set; }
+
+        /// <inheritdoc />
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            ISitecoreRenderingContext renderingContext = ViewContext?.HttpContext.GetSitecoreRenderingContext() ??
+                                             throw new NullReferenceException("EditingScriptsTagHelper: Sitecore RenderingContext is Null");
+
+            output.TagName = string.Empty;
+            string html = string.Empty;
+
+            if (renderingContext?.Response?.Content?.Sitecore?.Context?.IsEditing ?? false)
+            {
+                JsonDocument doc = JsonDocument.Parse(renderingContext?.Response?.Content.ContextRawData ?? string.Empty);
+                if (doc == null)
+                {
+                    throw new NullReferenceException("EditingScriptsTagHelper: Unable to process ContextRawData");
+                }
+
+                EditingContext? editingContext = JsonSerializer.Deserialize<EditingContext>(renderingContext?.Response?.Content.ContextRawData ?? string.Empty);
+                if (editingContext == null)
+                {
+                    return;
+                }
+
+                foreach (string script in editingContext.ClientScripts ?? [])
+                {
+                    html += $"<script type=\"text/javascript\" src=\"{script}\"></script>";
+                }
+
+                html += $@"
+                            <script id=""hrz-canvas-state"" type=""application/json"">
+                                {{
+                                    ""itemId"":""{editingContext?.ClientData?.CanvasState?.ItemId}"",
+                                    ""itemVersion"":{editingContext?.ClientData?.CanvasState?.ItemVersion},
+                                    ""siteName"":""{editingContext?.ClientData?.CanvasState?.SiteName}"",
+                                    ""language"":""{editingContext?.ClientData?.CanvasState?.Language}"",
+                                    ""deviceId"":""{editingContext?.ClientData?.CanvasState?.DeviceId}"",
+                                    ""pageMode"":""{editingContext?.ClientData?.CanvasState?.PageMode}"",
+                                    ""variant"":""{editingContext?.ClientData?.CanvasState?.Varient}""
+                                }}
+                            </script>
+                        ";
+
+                html += $"<script id=\"hrz-canvas-verification-token\" type=\"application/json\">{editingContext?.ClientData?.CanvasVerificationToken}</script>";
+            }
+
+            output.Content.SetHtmlContent(html);
+        }
+    }
+}

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/RenderingEngineOptionsExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/RenderingEngineOptionsExtensions.cs
@@ -223,7 +223,8 @@ public static class RenderingEngineOptionsExtensions
             sp => ActivatorUtilities.CreateInstance<ModelBoundViewComponentComponentRenderer<TModel>>(
                 sp,
                 RenderingEngineConstants.SitecoreViewComponents.DefaultSitecoreViewComponentName,
-                viewName));
+                viewName),
+            viewName);
 
         options.RendererRegistry.Add(options.RendererRegistry.Count, descriptor);
 
@@ -242,7 +243,7 @@ public static class RenderingEngineOptionsExtensions
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        ComponentRendererDescriptor descriptor = new(_ => true, services => ActivatorUtilities.CreateInstance<T>(services));
+        ComponentRendererDescriptor descriptor = new(_ => true, services => ActivatorUtilities.CreateInstance<T>(services), "defaultComponent");
         options.DefaultRenderer = descriptor;
 
         return options;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/ComponentRendererDescriptor.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/ComponentRendererDescriptor.cs
@@ -10,7 +10,8 @@
 /// <param name="factory">The factory method to create a new instance of the <see cref="IComponentRenderer"/>.</param>
 public class ComponentRendererDescriptor(
     Predicate<string> match,
-    Func<IServiceProvider, IComponentRenderer> factory)
+    Func<IServiceProvider, IComponentRenderer> factory,
+    string componentName)
 {
     private readonly Func<IServiceProvider, IComponentRenderer> _factory = factory ?? throw new ArgumentNullException(nameof(factory));
     private readonly object _lock = new();
@@ -21,6 +22,11 @@ public class ComponentRendererDescriptor(
     /// Gets a predicate used for matching Sitecore layout components.
     /// </summary>
     public Predicate<string> Match { get; } = match ?? throw new ArgumentNullException(nameof(match));
+
+    /// <summary>
+    /// Gets the name of the component.
+    /// </summary>
+    public string ComponentName { get; } = componentName;
 
     /// <summary>
     /// Gets an instance of an <see cref="IComponentRenderer"/>, creating one if it has not yet been instantiated.

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/LoggingComponentRenderer.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/LoggingComponentRenderer.cs
@@ -31,7 +31,8 @@ public class LoggingComponentRenderer(ILogger<LoggingComponentRenderer> logger)
 
         return new ComponentRendererDescriptor(
             match,
-            sp => ActivatorUtilities.CreateInstance<LoggingComponentRenderer>(sp));
+            sp => ActivatorUtilities.CreateInstance<LoggingComponentRenderer>(sp),
+            string.Empty);
     }
 
     /// <inheritdoc />

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/PartialViewComponentRenderer.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/PartialViewComponentRenderer.cs
@@ -35,7 +35,8 @@ public class PartialViewComponentRenderer : IComponentRenderer
         ArgumentException.ThrowIfNullOrWhiteSpace(locator);
         return new ComponentRendererDescriptor(
             match,
-            sp => ActivatorUtilities.CreateInstance<PartialViewComponentRenderer>(sp, locator));
+            sp => ActivatorUtilities.CreateInstance<PartialViewComponentRenderer>(sp, locator),
+            locator);
     }
 
     /// <inheritdoc />

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/ViewComponentComponentRenderer.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Rendering/ViewComponentComponentRenderer.cs
@@ -37,7 +37,8 @@ public class ViewComponentComponentRenderer : IComponentRenderer
 
         return new ComponentRendererDescriptor(
             match,
-            sp => ActivatorUtilities.CreateInstance<ViewComponentComponentRenderer>(sp, locator));
+            sp => ActivatorUtilities.CreateInstance<ViewComponentComponentRenderer>(sp, locator),
+            string.Empty);
     }
 
     /// <inheritdoc />

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 
@@ -13,8 +14,10 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement(RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag, Attributes = RenderingEngineConstants.SitecoreTagHelpers.DateTagHelperAttribute, TagStructure = TagStructure.NormalOrSelfClosing)]
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.AspForTagHelperAttribute)]
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.DateTagHelperAttribute)]
-public class DateTagHelper : TagHelper
+public class DateTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+
     /// <summary>
     /// Gets or sets the model value.
     /// </summary>
@@ -68,6 +71,16 @@ public class DateTagHelper : TagHelper
 
         HtmlString html = outputEditableMarkup ? new HtmlString(field.EditableMarkup) : new HtmlString(formattedDate);
 
-        output.Content.SetHtmlContent(html);
+        if (field.OpeningChrome != null)
+        {
+            output.Content.AppendHtml(chromeRenderer.Render(field.OpeningChrome));
+        }
+
+        output.Content.AppendHtml(html);
+
+        if (field.ClosingChrome != null)
+        {
+            output.Content.AppendHtml(chromeRenderer.Render(field.ClosingChrome));
+        }
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/DateTagHelper.cs
@@ -16,7 +16,7 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.DateTagHelperAttribute)]
 public class DateTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
-    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
     /// <summary>
     /// Gets or sets the model value.

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Properties;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 
@@ -16,7 +17,7 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement(RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag, Attributes = RenderingEngineConstants.SitecoreTagHelpers.ImageTagHelperAttribute, TagStructure = TagStructure.NormalOrSelfClosing)]
 [HtmlTargetElement("img", Attributes = RenderingEngineConstants.SitecoreTagHelpers.AspForTagHelperAttribute)]
 [HtmlTargetElement("img", Attributes = RenderingEngineConstants.SitecoreTagHelpers.ImageTagHelperAttribute)]
-public class ImageTagHelper : TagHelper
+public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
     private const string ImgTag = "img";
     private const string ScrAttribute = "src";
@@ -28,6 +29,7 @@ public class ImageTagHelper : TagHelper
     private const string VSpaceAttribute = "vspace";
     private const string TitleAttribute = "title";
     private const string BorderAttribute = "border";
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
 
     /// <summary>
     /// Gets or sets the model value.
@@ -80,7 +82,17 @@ public class ImageTagHelper : TagHelper
         {
             if (output.TagName == null)
             {
-                output.Content.SetHtmlContent(GenerateImage(field, output));
+                if (field.OpeningChrome != null)
+                {
+                    output.Content.AppendHtml(chromeRenderer.Render(field.OpeningChrome));
+                }
+
+                output.Content.AppendHtml(GenerateImage(field, output));
+
+                if (field.ClosingChrome != null)
+                {
+                    output.Content.AppendHtml(chromeRenderer.Render(field.ClosingChrome));
+                }
             }
             else
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -29,7 +29,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private const string VSpaceAttribute = "vspace";
     private const string TitleAttribute = "title";
     private const string BorderAttribute = "border";
-    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
     /// <summary>
     /// Gets or sets the model value.

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/LinkTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/LinkTagHelper.cs
@@ -53,7 +53,7 @@ public class LinkTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         HyperLinkField? field = LinkModel ?? For?.Model as HyperLinkField;
         bool outputEditableMarkup = Editable &&
-                                    ((!string.IsNullOrEmpty(field?.EditableMarkupFirst) && !string.IsNullOrWhiteSpace(field.EditableMarkupLast)) || (field.OpeningChrome != null && field.ClosingChrome != null));
+                                    ((!string.IsNullOrEmpty(field?.EditableMarkupFirst) && !string.IsNullOrWhiteSpace(field?.EditableMarkupLast)) || (field?.OpeningChrome != null && field?.ClosingChrome != null));
 
         if (field == null || (string.IsNullOrWhiteSpace(field.Value.Href) && !outputEditableMarkup))
         {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/NumberTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/NumberTagHelper.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 
@@ -12,8 +13,10 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement(RenderingEngineConstants.SitecoreTagHelpers.NumberHtmlTag, Attributes = RenderingEngineConstants.SitecoreTagHelpers.NumberTagHelperAttribute, TagStructure = TagStructure.NormalOrSelfClosing)]
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.AspForTagHelperAttribute)]
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.NumberTagHelperAttribute)]
-public class NumberTagHelper : TagHelper
+public class NumberTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+
     /// <summary>
     /// Gets or sets the model value.
     /// </summary>
@@ -70,6 +73,16 @@ public class NumberTagHelper : TagHelper
         bool outputEditableMarkup = Editable && !string.IsNullOrEmpty(field.EditableMarkup);
         string value = outputEditableMarkup ? field.EditableMarkup : formattedNumber;
 
-        output.Content.SetHtmlContent(value);
+        if (field.OpeningChrome != null)
+        {
+            output.Content.AppendHtml(chromeRenderer.Render(field.OpeningChrome));
+        }
+
+        output.Content.AppendHtml(value);
+
+        if (field.ClosingChrome != null)
+        {
+            output.Content.AppendHtml(chromeRenderer.Render(field.ClosingChrome));
+        }
     }
 }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/NumberTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/NumberTagHelper.cs
@@ -15,7 +15,7 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.NumberTagHelperAttribute)]
 public class NumberTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
-    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
     /// <summary>
     /// Gets or sets the model value.

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/RichTextTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/RichTextTagHelper.cs
@@ -16,7 +16,7 @@ namespace Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 [HtmlTargetElement("*", Attributes = RenderingEngineConstants.SitecoreTagHelpers.TextTagHelperAttribute)]
 public class RichTextTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 {
-    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer;
+    private readonly IEditableChromeRenderer chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
     /// <summary>
     /// Gets or sets the model value.

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldConverterTests.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Tests/Serialization/Converter/FieldConverterTests.cs
@@ -17,12 +17,12 @@ public class FieldConverterTests
 
     public static TheoryData<IFieldReader, string> Fields => new()
     {
-        { new TextField("Test"), """{"editable":"","value":"Test"}""" },
-        { new RichTextField("Test Noencoding", false), """{"editable":"","value":"Test Noencoding"}""" },
-        { new RichTextField("Test%20Encoded"), """{"editable":"","value":"Test Encoded"}""" },
-        { new CheckboxField(true), """{"editable":"","value":true}""" },
-        { new CheckboxField(false), """{"editable":""}""" },
-        { new ImageField(new Image { Alt = "Alt Text", Border = 1, Class = "styleclass", HSpace = 1, Height = 100, Src = "https://image.com/test.jpg", Title = "Title", VSpace = 1, Width = 100 }), """{"editable":"","value":{"src":"https://image.com/test.jpg","alt":"Alt Text","height":"100","width":"100","title":"Title","hSpace":"1","vSpace":"1","border":"1","class":"styleclass"}}""" }
+        { new TextField("Test"), """{"editable":"","Id":"","value":"Test"}""" },
+        { new RichTextField("Test Noencoding", false), """{"editable":"","Id":"","value":"Test Noencoding"}""" },
+        { new RichTextField("Test%20Encoded"), """{"editable":"","Id":"","value":"Test Encoded"}""" },
+        { new CheckboxField(true), """{"editable":"","Id":"","value":true}""" },
+        { new CheckboxField(false), """{"editable":"","Id":""}""" },
+        { new ImageField(new Image { Alt = "Alt Text", Border = 1, Class = "styleclass", HSpace = 1, Height = 100, Src = "https://image.com/test.jpg", Title = "Title", VSpace = 1, Width = 100 }), """{"editable":"","Id":"","value":{"src":"https://image.com/test.jpg","alt":"Alt Text","height":"100","width":"100","title":"Title","hSpace":"1","vSpace":"1","border":"1","class":"styleclass"}}""" }
     };
 
     [Fact]

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Extensions/PagesAppConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Extensions/PagesAppConfigurationExtensionsFixture.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+using Sitecore.AspNetCore.SDK.Pages.Extensions;
+using Xunit;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.Extensions
+{
+    public class PagesAppConfigurationExtensionsFixture
+    {
+        [Fact]
+        public void UseSitecorePages_AppIsNull_ExceptionIsThrown()
+        {
+            // Act
+            Action action = () => PagesAppConfigurationExtensions.UseSitecorePages(null!);
+
+            // Assert
+            action.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/GraphQL/GraphQLClientFactoryFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/GraphQL/GraphQLClientFactoryFixture.cs
@@ -1,0 +1,79 @@
+﻿using AutoFixture.Idioms;
+using FluentAssertions;
+using GraphQL.Client.Http;
+using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
+using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
+using Sitecore.AspNetCore.SDK.Pages.GraphQL;
+using Xunit;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.GraphQL
+{
+    public class GraphQLClientFactoryFixture
+    {
+        [Theory]
+        [AutoNSubstituteData]
+        public void Ctor_InvalidArgs_Throws(GuardClauseAssertion guard)
+        {
+            guard.VerifyConstructors<GraphQLClientFactory>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void GenerateClient_NullUriDefaultsToEdgePlatformUri(GraphQLClientFactory sut)
+        {
+            // Act
+            var result = sut.GenerateClient(null, string.Empty, false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<GraphQLHttpClient>();
+            result.As<GraphQLHttpClient>().Options.EndPoint?.AbsoluteUri.Should().Contain("https://edge-platform.sitecorecloud.io/v1/content/api/graphql/v1");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void GenerateClient_OverriddenUriUsedInClient(GraphQLClientFactory sut)
+        {
+            // Act
+            var result = sut.GenerateClient(new Uri("https://some.domain.com"), string.Empty, false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<GraphQLHttpClient>();
+            result.As<GraphQLHttpClient>().Options.EndPoint?.AbsoluteUri.Should().Contain("https://some.domain.com");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void GenerateClient_ContextIdIsAppendedToClientUri(GraphQLClientFactory sut)
+        {
+            // Arrange
+            sut = new GraphQLClientFactory("1234");
+
+            // Act
+            var result = sut.GenerateClient(null, string.Empty, false);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<GraphQLHttpClient>();
+            result.As<GraphQLHttpClient>().Options.EndPoint?.AbsoluteUri.Should().Contain("sitecoreContextId=1234");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void GenerateClient_CorrectParamsAreSetWhenGeneratingClient(GraphQLClientFactory sut)
+        {
+            // Arrange
+            sut = new GraphQLClientFactory("1234");
+
+            // Act
+            var result = sut.GenerateClient(null, "layout_kid_1234", true);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<GraphQLHttpClient>();
+            result.As<GraphQLHttpClient>().HttpClient.DefaultRequestHeaders.GetValues("sc_layoutKind").Should().Equal(["layout_kid_1234"]);
+            result.As<GraphQLHttpClient>().HttpClient.DefaultRequestHeaders.GetValues("sc_editmode").Should().Equal([true.ToString()]);
+        }
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Middleware/PageSetupMiddlewareFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Middleware/PageSetupMiddlewareFixture.cs
@@ -1,0 +1,165 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using AutoFixture;
+using AutoFixture.Idioms;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using NSubstitute;
+using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
+using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+using Sitecore.AspNetCore.SDK.Pages.Configuration;
+using Sitecore.AspNetCore.SDK.Pages.Middleware;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Configuration;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
+using Xunit;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.Middleware
+{
+    public class PageSetupMiddlewareFixture
+    {
+        private const string ValidConfigEndpoint = "/api/editing/config";
+        private const string ValidRenderEndpoint = "/api/editing/render";
+        private const string ValidEditingOrigin = "http://some.editing.domain";
+        private const string ValidOrigins = "http://some.origin.domain";
+        private const string ValidEditingSecret = "editing_secret_1234";
+
+        [ExcludeFromCodeCoverage]
+        public static Action<IFixture> AutoSetup => f =>
+        {
+            RequestDelegate requestDelegate = Substitute.For<RequestDelegate>();
+            f.Inject(requestDelegate);
+
+            IOptions<PagesOptions> pagesOptions = Substitute.For<IOptions<PagesOptions>>();
+            PagesOptions PagesOptionsValues = new PagesOptions
+            {
+                ConfigEndpoint = ValidConfigEndpoint,
+                RenderEndpoint = ValidRenderEndpoint,
+                ValidEditingOrigin = ValidEditingOrigin,
+                ValidOrigins = ValidOrigins,
+                EditingSecret = ValidEditingSecret
+            };
+            pagesOptions.Value.Returns(PagesOptionsValues);
+            f.Inject(pagesOptions);
+
+            ILogger<PageSetupMiddleware> logger = Substitute.For<ILogger<PageSetupMiddleware>>();
+            f.Inject(logger);
+
+            IOptions<RenderingEngineOptions > renderingEngineOptions = Substitute.For<IOptions<RenderingEngineOptions>>();
+            string componentName = "TestComponent";
+            ComponentRendererDescriptor componentRendererDescriptor = new(name => name == componentName, _ => null!, componentName);
+            RenderingEngineOptions renderingEngineOptionsValues = new RenderingEngineOptions
+            {
+                RendererRegistry = new SortedList<int, ComponentRendererDescriptor>
+                {
+                    { 1, componentRendererDescriptor }
+                }
+
+            };
+            renderingEngineOptions.Value.Returns(renderingEngineOptionsValues);
+            f.Inject(renderingEngineOptions);
+        };
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void Ctor_InvalidArgs_Throws(GuardClauseAssertion guard)
+        {
+            guard.VerifyConstructors<PageSetupMiddleware>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Invoke_RequestIsntConfigOrRender_NextDelegateCalled(RequestDelegate requestDelegate, IOptions<PagesOptions> pageOptions, ILogger<PageSetupMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+        {
+            // Arrange
+            PageSetupMiddleware sut = new(requestDelegate, pageOptions, logger, renderingEngineOptions);
+            HttpContext httpContext = Substitute.For<HttpContext>();
+            HttpRequest httpRequest = Substitute.For<HttpRequest>();
+            httpRequest.Method.Returns("Post");
+            httpContext.Request.Returns(httpRequest);
+
+            // Act
+            await sut.Invoke(httpContext);
+
+            // Assert
+            await requestDelegate.Received()(httpContext);
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Invoke_ConfigRequest_InvalidEditingSecret_NextDelegateCalled(RequestDelegate requestDelegate, IOptions<PagesOptions> pageOptions, ILogger<PageSetupMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+        {
+            // Arrange
+            PageSetupMiddleware sut = new(requestDelegate, pageOptions, logger, renderingEngineOptions);
+            HttpContext httpContext = Substitute.For<HttpContext>();
+            httpContext.Request.Method.Returns("GET");
+            httpContext.Request.Path.Returns(new PathString(ValidConfigEndpoint));
+            httpContext.Request.Query.Returns(new QueryCollection(new Dictionary<string, StringValues> { { "secret", new StringValues("incorrect_secret_value") } }));
+
+            // Act
+            await sut.Invoke(httpContext);
+
+            // Assert
+            logger.Received().Log(LogLevel.Error, Arg.Any<EventId>(), Arg.Is<object>(o => o.ToString() == "Invalid Pages Editing Secret Value"), null, Arg.Any<Func<object, Exception?, string>>());
+            await requestDelegate.Received()(httpContext);
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Invoke_ConfigRequest_InvalidEditingOrigin_NextDelegateCalled(RequestDelegate requestDelegate, IOptions<PagesOptions> pageOptions, ILogger<PageSetupMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+        {
+            // Arrange
+            PageSetupMiddleware sut = new(requestDelegate, pageOptions, logger, renderingEngineOptions);
+            HttpContext httpContext = Substitute.For<HttpContext>();
+            httpContext.Request.Method.Returns("GET");
+            httpContext.Request.Path.Returns(new PathString(ValidConfigEndpoint));
+            httpContext.Request.Query.Returns(new QueryCollection(new Dictionary<string, StringValues> { { "secret", new StringValues(ValidEditingSecret) } }));
+            httpContext.Request.Headers.Returns(new HeaderDictionary(new Dictionary<string, StringValues> { { "Origin", new StringValues("http://an.invalid.origin.domain") } }));
+
+            // Act
+            await sut.Invoke(httpContext);
+
+            // Assert
+            logger.Received().Log(LogLevel.Error, Arg.Any<EventId>(), Arg.Is<object>(o => o.ToString() == "Invalid Pages Editing Origin"), null, Arg.Any<Func<object, Exception?, string>>());
+            await requestDelegate.Received()(httpContext);
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Invoke_ConfigRequest_ValidResponseReturned(RequestDelegate requestDelegate, IOptions<PagesOptions> pageOptions, ILogger<PageSetupMiddleware> logger, IOptions<RenderingEngineOptions> renderingEngineOptions)
+        {
+            // Arrange
+            PageSetupMiddleware sut = new(requestDelegate, pageOptions, logger, renderingEngineOptions);
+            HttpContext httpContext = Substitute.For<HttpContext>();
+            httpContext.Request.Method.Returns("GET");
+            httpContext.Request.Path.Returns(new PathString(ValidConfigEndpoint));
+            httpContext.Request.Query.Returns(new QueryCollection(new Dictionary<string, StringValues> { { "secret", new StringValues(ValidEditingSecret) } }));
+            httpContext.Request.Headers.Returns(new HeaderDictionary(new Dictionary<string, StringValues> { { "Origin", new StringValues(ValidEditingOrigin) } }));
+            MemoryStream memoryStream = new();
+            httpContext.Response.Body = memoryStream;
+
+            // Act
+            await sut.Invoke(httpContext);
+
+            // Assert
+            logger.Received().Log(LogLevel.Debug, Arg.Any<EventId>(), Arg.Is<object>(o => o.ToString() == "Processing valid Pages Config request"), null, Arg.Any<Func<object, Exception?, string>>());
+
+            byte[] contents = memoryStream.ToArray();
+            string returnedBody = Encoding.UTF8.GetString(contents);
+            string expectedResponse = "\r\n                {\r\n                    \"components\": [\r\n                        \"TestComponent\"\r\n                    ],\r\n                    \"packages\": {\r\n                    },\r\n                    \"editMode\": \"metadata\"\r\n                }\r\n            ";
+            Assert.Equal(expectedResponse, returnedBody);
+
+            httpContext.Response.Headers.ContentSecurityPolicy.Should().Equal($"frame-ancestors 'self' {ValidOrigins} {ValidEditingOrigin}");
+            httpContext.Response.Headers.AccessControlAllowOrigin.Should().Equal(ValidEditingOrigin);
+            httpContext.Response.Headers.AccessControlAllowMethods.Should().Equal("GET, POST, OPTIONS, PUT, PATCH, DELETE");
+            httpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+            httpContext.Response.ContentType.Should().Be("application/json");
+
+            await requestDelegate.DidNotReceive()(httpContext);
+        }
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/Constants.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/Constants.cs
@@ -1,0 +1,304 @@
+﻿using GraphQL;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization.Fields;
+using Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+using System.Text.Json;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.Request.Handlers.GraphQL
+{
+    public static class Constants
+    {
+        public static GraphQLResponse<EditingLayoutQueryResponse> SimpleEditingLayoutQueryResponse
+        {
+            get
+            {
+                return new GraphQLResponse<EditingLayoutQueryResponse>
+                {
+                    Data = new EditingLayoutQueryResponse
+                    {
+                        Item = new ItemModel
+                        {
+                            Rendered = JsonDocument.Parse("{\"test\":\"value\"}").RootElement
+                        },
+                        Site = new Pages.Request.Handlers.GraphQL.Site
+                        {
+                            SiteInfo = new SiteInfo
+                            {
+                                Dictionary = new SiteInfoDictionary
+                                {
+                                    PageInfo = new PageInfo
+                                    {
+                                        HasNext = false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static GraphQLResponse<EditingLayoutQueryResponse> EditingLayoutQueryResponseWithDictionaryPaging
+        {
+            get
+            {
+                return new GraphQLResponse<EditingLayoutQueryResponse>
+                {
+                    Data = new EditingLayoutQueryResponse
+                    {
+                        Item = new ItemModel
+                        {
+                            Rendered = JsonDocument.Parse("{\"test\":\"value\"}").RootElement
+                        },
+                        Site = new Pages.Request.Handlers.GraphQL.Site
+                        {
+                            SiteInfo = new SiteInfo
+                            {
+                                Dictionary = new SiteInfoDictionary
+                                {
+                                    PageInfo = new PageInfo
+                                    {
+                                        HasNext = true,
+                                        EndCursor = "cursor_value_1234"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static GraphQLResponse<EditingDictionaryResponse> EditingDictionaryResponse
+        {
+            get
+            {
+                return new GraphQLResponse<EditingDictionaryResponse>
+                {
+                    Data = new EditingDictionaryResponse
+                    {
+                        Site = new Pages.Request.Handlers.GraphQL.Site
+                        {
+                            SiteInfo = new SiteInfo
+                            {
+                                Dictionary = new SiteInfoDictionary
+                                {
+                                    Results = new List<SiteInfoDictionaryItem>
+                                    {
+                                        new SiteInfoDictionaryItem
+                                        {
+                                            Key = "key1",
+                                            Value = "value1"
+                                        },
+                                        new SiteInfoDictionaryItem
+                                        {
+                                            Key = "key2",
+                                            Value = "value2"
+                                        }
+                                    },
+                                    PageInfo = new PageInfo
+                                    {
+                                        HasNext = false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static GraphQLResponse<EditingLayoutQueryResponse> MockEditingLayoutQueryResponse
+        {
+            get
+            {
+                return new GraphQLResponse<EditingLayoutQueryResponse>
+                {
+                    Data = new EditingLayoutQueryResponse
+                    {
+                        Item = new ItemModel
+                        {
+                            Rendered = JsonDocument.Parse(@"{ ""sitecore"" : {}}").RootElement
+                        },
+                        Site = new Pages.Request.Handlers.GraphQL.Site
+                        {
+                            SiteInfo = new SiteInfo
+                            {
+                                Dictionary = new SiteInfoDictionary
+                                {
+                                    PageInfo = new PageInfo
+                                    {
+                                        HasNext = false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static SitecoreLayoutResponseContent MockLayoutResponse_Placeholder
+        {
+            get
+            {
+                 return new SitecoreLayoutResponseContent
+                 {
+                     Sitecore = new SitecoreData
+                     {
+                         Route = new Route
+                         {
+                             Placeholders = new Dictionary<string, Placeholder>
+                            {
+                                {
+                                    "placeholder_1", new Placeholder()
+                                }
+                            }
+                         }
+                     }
+                 };
+            }
+        }
+
+        public static SitecoreLayoutResponseContent MockLayoutResponse_NestedPlaceholder
+        {
+            get
+            {
+                return new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Route = new Route
+                        {
+                            Placeholders = new Dictionary<string, Placeholder>
+                            {
+                                {
+                                    "placeholder_1", new Placeholder
+                                    {
+                                        new Component
+                                        {
+                                            Name = "component_1",
+                                            Id = "component_1",
+                                            Placeholders = new Dictionary<string, Placeholder>
+                                            {
+                                                {
+                                                    "nested_placeholder_1", new Placeholder()
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static SitecoreLayoutResponseContent MockLayoutResponse_WithComponentInPlaceholder
+        {
+            get
+            {
+                return new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Route = new Route
+                        {
+                            Placeholders = new Dictionary<string, Placeholder>
+                            {
+                                {
+                                    "placeholder_1", new Placeholder
+                                    {
+                                        new Component
+                                        {
+                                            Name = "component_1",
+                                            Id = "component_1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static SitecoreLayoutResponseContent MockLayoutResponse_ComponentInNestedPlaceholder
+        {
+            get
+            {
+                return new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Route = new Route
+                        {
+                            Placeholders = new Dictionary<string, Placeholder>
+                            {
+                                {
+                                    "placeholder_1", new Placeholder
+                                    {
+                                        new Component
+                                        {
+                                            Name = "component_1",
+                                            Id = "component_1",
+                                            Placeholders = new Dictionary<string, Placeholder>
+                                            {
+                                                {
+                                                    "nested_placeholder_1", new Placeholder
+                                                    {
+                                                        new Component
+                                                        {
+                                                            Name = "nested_component_2",
+                                                            Id = "nested_component_2"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        public static SitecoreLayoutResponseContent MockLayoutResponse_ComponentWithField
+        {
+            get
+            {
+                return new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Route = new Route
+                        {
+                            Placeholders = new Dictionary<string, Placeholder>
+                            {
+                                {
+                                    "placeholder_1", new Placeholder
+                                    {
+                                        new Component
+                                        {
+                                            Name = "component_1",
+                                            Id = "component_1",
+                                            Fields = new Dictionary<string, IFieldReader>
+                                            {
+                                                { "field_1", new JsonSerializedField(JsonDocument.Parse("{\"metadata\":{\"datasource\":{\"id\":\"datasource_id\",\"language\":\"en\",\"revision\":\"revision_1\",\"version\":1},\"title\":\"Text\",\"fieldId\":\"field_id\",\"fieldType\":\"Text\",\"rawValue\":\"field_raw_value\"},\"value\":\"field_value\"}")) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
@@ -1,0 +1,166 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using AutoFixture;
+using AutoFixture.Idioms;
+using Castle.Core.Logging;
+using FluentAssertions;
+using GraphQL;
+using GraphQL.Client.Abstractions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
+using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
+using Sitecore.AspNetCore.SDK.Pages.GraphQL;
+using Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
+using Xunit;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.Request.Handlers.GraphQL
+{
+    public class GraphQLEditingServiceHandlerFixture
+    {
+        [ExcludeFromCodeCoverage]
+        public static Action<IFixture> AutoSetup => f =>
+        {
+            IGraphQLClient client = Substitute.For<IGraphQLClient>();
+            IGraphQLClientFactory clientFactory = Substitute.For<IGraphQLClientFactory>();
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(new GraphQLResponse<EditingLayoutQueryResponse>
+            {
+                Data = new EditingLayoutQueryResponse
+                {
+                    Item = new ItemModel
+                    {
+                        Rendered = JsonDocument.Parse("{\"test\":\"value\"}").RootElement
+                    },
+                    Site = new Site
+                    {
+                        SiteInfo = new SiteInfo
+                        {
+                            Dictionary = new SiteInfoDictionary
+                            {
+                                PageInfo = new PageInfo
+                                {
+                                    HasNext = false
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            f.Inject(clientFactory);
+        };
+
+        [Theory]
+        [AutoNSubstituteData]
+        public void Ctor_InvalidArgs_Throws(GuardClauseAssertion guard)
+        {
+            guard.VerifyConstructors<GraphQLEditingServiceHandler>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_RequestParamIsNull_ErrorThrown(GraphQLEditingServiceHandler sut)
+        {
+            // Act
+            Func<Task> act = async () => { await sut.Request(null!, string.Empty); };
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_HandlerNameIsNull_ErrorThrown(GraphQLEditingServiceHandler sut)
+        {
+            // Act
+            Func<Task> act = async () => { await sut.Request([], null!); };
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_HandlerNameIsEmptyString_ErrorThrown(GraphQLEditingServiceHandler sut)
+        {
+            // Act
+            Func<Task> act = async () => { await sut.Request([], string.Empty); };
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_NotValidEditingRequest_ErrorThrown(GraphQLEditingServiceHandler sut)
+        {
+            // Arrange
+            SitecoreLayoutRequest request = [];
+
+            // Act
+            Func<Task> act = async () => { await sut.Request(request, "editingHandler"); };
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("GraphQLEditingServiceHandler: Error attempting to process non-editing request");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_NoLanguageSet_ErrorThrown(GraphQLEditingServiceHandler sut)
+        {
+            // Arrange
+            SitecoreLayoutRequest request = new SitecoreLayoutRequest
+            {
+                {
+                    "sc_request_headers_key" , new Dictionary<string, string[]>()
+                    {
+                        { "mode", ["edit"] }
+                    }
+                }
+            };
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().ContainItemsAssignableTo<ItemNotFoundSitecoreLayoutServiceClientException>();
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_NoErrorsThrown(IGraphQLClientFactory clientFactory)
+        {
+            // Arrange
+            GraphQLEditingServiceHandler sut = new(clientFactory, Substitute.For<ISitecoreLayoutSerializer>(), Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+            SitecoreLayoutRequest request = new()
+            {
+                {
+                    "sc_request_headers_key" , new Dictionary<string, string[]>()
+                    {
+                        { "mode", ["edit"] },
+                        { "language", ["en"] },
+                        { "sc_layoutKind", ["Final"] },
+                        { "sc_itemid", ["item_1234"] },
+                        { "sc_version", ["version_1234"] },
+                        { "sc_site", ["site_1234"] }
+                    }
+                },
+                {
+                    "sc_lang", "en"
+                }
+            };
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+        }
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Request/Handlers/GraphQL/GraphQLEditingServiceHandlerFixture.cs
@@ -1,8 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using AutoFixture;
 using AutoFixture.Idioms;
-using Castle.Core.Logging;
 using FluentAssertions;
 using GraphQL;
 using GraphQL.Client.Abstractions;
@@ -12,9 +10,10 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Exceptions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Request;
-using Sitecore.AspNetCore.SDK.LayoutService.Client.Request.Handlers.GraphQL;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization.Fields;
 using Sitecore.AspNetCore.SDK.Pages.GraphQL;
 using Sitecore.AspNetCore.SDK.Pages.Request.Handlers.GraphQL;
 using Xunit;
@@ -27,33 +26,34 @@ namespace Sitecore.AspNetCore.SDK.Pages.Tests.Request.Handlers.GraphQL
         public static Action<IFixture> AutoSetup => f =>
         {
             IGraphQLClient client = Substitute.For<IGraphQLClient>();
-            IGraphQLClientFactory clientFactory = Substitute.For<IGraphQLClientFactory>();
-            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
-            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(new GraphQLResponse<EditingLayoutQueryResponse>
-            {
-                Data = new EditingLayoutQueryResponse
-                {
-                    Item = new ItemModel
-                    {
-                        Rendered = JsonDocument.Parse("{\"test\":\"value\"}").RootElement
-                    },
-                    Site = new Site
-                    {
-                        SiteInfo = new SiteInfo
-                        {
-                            Dictionary = new SiteInfoDictionary
-                            {
-                                PageInfo = new PageInfo
-                                {
-                                    HasNext = false
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            f.Inject(client);
 
+            IGraphQLClientFactory clientFactory = Substitute.For<IGraphQLClientFactory>();
             f.Inject(clientFactory);
+
+            ISitecoreLayoutSerializer mockSerializer = Substitute.For<ISitecoreLayoutSerializer>();
+            f.Inject(mockSerializer);
+
+            SitecoreLayoutRequest request = new()
+            {
+                {
+                    "sc_request_headers_key" , new Dictionary<string, string[]>()
+                    {
+                        { "mode", ["edit"] },
+                        { "language", ["en"] },
+                        { "sc_layoutKind", ["Final"] },
+                        { "sc_itemid", ["item_1234"] },
+                        { "sc_version", ["version_1234"] }
+                    }
+                },
+                {
+                    "sc_lang", "en"
+                },
+                {
+                    "sc_site", "site_1234"
+                }
+            };
+            f.Inject(request);
         };
 
         [Theory]
@@ -134,33 +134,168 @@ namespace Sitecore.AspNetCore.SDK.Pages.Tests.Request.Handlers.GraphQL
 
         [Theory]
         [AutoNSubstituteData]
-        public async Task Request_ValidRequest_NoErrorsThrown(IGraphQLClientFactory clientFactory)
+        public async Task Request_ValidRequest_NoErrorsThrown(IGraphQLClientFactory clientFactory, IGraphQLClient client, SitecoreLayoutRequest request)
         {
             // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.SimpleEditingLayoutQueryResponse);
             GraphQLEditingServiceHandler sut = new(clientFactory, Substitute.For<ISitecoreLayoutSerializer>(), Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
-            SitecoreLayoutRequest request = new()
-            {
-                {
-                    "sc_request_headers_key" , new Dictionary<string, string[]>()
-                    {
-                        { "mode", ["edit"] },
-                        { "language", ["en"] },
-                        { "sc_layoutKind", ["Final"] },
-                        { "sc_itemid", ["item_1234"] },
-                        { "sc_version", ["version_1234"] },
-                        { "sc_site", ["site_1234"] }
-                    }
-                },
-                {
-                    "sc_lang", "en"
-                }
-            };
 
             // Act
             SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
 
             // Assert
             result.Errors.Should().BeEmpty();
+            await client.Received(1).SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>());
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_DictionaryRequestMade(IGraphQLClientFactory clientFactory, IGraphQLClient client, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.EditingLayoutQueryResponseWithDictionaryPaging);
+            client.SendQueryAsync<EditingDictionaryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.EditingDictionaryResponse);
+            GraphQLEditingServiceHandler sut = new(clientFactory, Substitute.For<ISitecoreLayoutSerializer>(), Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Asset
+            result.Errors.Should().BeEmpty();
+            await client.Received(1).SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>());
+            await client.Received(1).SendQueryAsync<EditingDictionaryResponse>(Arg.Any<GraphQLRequest>());
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_PlaceholderChromesAreAdded(IGraphQLClientFactory clientFactory, IGraphQLClient client, ISitecoreLayoutSerializer mockSerializer, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.MockEditingLayoutQueryResponse);
+            mockSerializer.Deserialize(Arg.Any<string>()).Returns(Constants.MockLayoutResponse_Placeholder);
+            GraphQLEditingServiceHandler sut = new(clientFactory, mockSerializer, Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"].Count.Should().Be(2);
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][0].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][0].As<EditableChrome>().Attributes["chrometype"].Should().Be("placeholder");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][0].As<EditableChrome>().Attributes["kind"].Should().Be("open");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][0].As<EditableChrome>().Attributes["id"].Should().Be($"placeholder_1_{Guid.Empty.ToString()}");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].As<EditableChrome>().Attributes["chrometype"].Should().Be("placeholder");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].As<EditableChrome>().Attributes["kind"].Should().Be("close");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_NestedPlaceholderChromesAreAdded(IGraphQLClientFactory clientFactory, IGraphQLClient client, ISitecoreLayoutSerializer mockSerializer, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.MockEditingLayoutQueryResponse);
+            mockSerializer.Deserialize(Arg.Any<string>()).Returns(Constants.MockLayoutResponse_NestedPlaceholder);
+            GraphQLEditingServiceHandler sut = new(clientFactory, mockSerializer, Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][0].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][0].As<EditableChrome>().Attributes["chrometype"].Should().Be("placeholder");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][0].As<EditableChrome>().Attributes["kind"].Should().Be("open");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][0].As<EditableChrome>().Attributes["id"].Should().Be("container-{*}_component_1");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].As<EditableChrome>().Attributes["chrometype"].Should().Be("placeholder");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].As<EditableChrome>().Attributes["kind"].Should().Be("close");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_RenderingChromesAreAdded(IGraphQLClientFactory clientFactory, IGraphQLClient client, ISitecoreLayoutSerializer mockSerializer, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.MockEditingLayoutQueryResponse);
+            mockSerializer.Deserialize(Arg.Any<string>()).Returns(Constants.MockLayoutResponse_WithComponentInPlaceholder);
+            GraphQLEditingServiceHandler sut = new(clientFactory, mockSerializer, Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"].Count.Should().Be(5);
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].As<EditableChrome>().Attributes["chrometype"].Should().Be("rendering");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].As<EditableChrome>().Attributes["kind"].Should().Be("open");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][1].As<EditableChrome>().Attributes["id"].Should().Be($"component_1");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][3].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][3].As<EditableChrome>().Attributes["chrometype"].Should().Be("rendering");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][3].As<EditableChrome>().Attributes["kind"].Should().Be("close");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_RenderingInNestedPlaceholderChromesAreAdded(IGraphQLClientFactory clientFactory, IGraphQLClient client, ISitecoreLayoutSerializer mockSerializer, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.MockEditingLayoutQueryResponse);
+            mockSerializer.Deserialize(Arg.Any<string>()).Returns(Constants.MockLayoutResponse_ComponentInNestedPlaceholder);
+            GraphQLEditingServiceHandler sut = new(clientFactory, mockSerializer, Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"].Count.Should().Be(5);
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].As<EditableChrome>().Attributes["chrometype"].Should().Be("rendering");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].As<EditableChrome>().Attributes["kind"].Should().Be("open");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][1].As<EditableChrome>().Attributes["id"].Should().Be($"nested_component_2");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][3].Should().BeOfType<EditableChrome>();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][3].As<EditableChrome>().Attributes["chrometype"].Should().Be("rendering");
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Placeholders["nested_placeholder_1"][3].As<EditableChrome>().Attributes["kind"].Should().Be("close");
+        }
+
+        [Theory]
+        [AutoNSubstituteData]
+        public async Task Request_ValidRequest_FieldRenderingChromesAreAdded(IGraphQLClientFactory clientFactory, IGraphQLClient client, ISitecoreLayoutSerializer mockSerializer, SitecoreLayoutRequest request)
+        {
+            // Arrange
+            clientFactory.GenerateClient(Arg.Any<string>(), Arg.Any<bool>()).Returns(client);
+            client.SendQueryAsync<EditingLayoutQueryResponse>(Arg.Any<GraphQLRequest>()).Returns(Constants.MockEditingLayoutQueryResponse);
+            mockSerializer.Deserialize(Arg.Any<string>()).Returns(Constants.MockLayoutResponse_ComponentWithField);
+            GraphQLEditingServiceHandler sut = new(clientFactory, mockSerializer, Substitute.For<ILogger<GraphQLEditingServiceHandler>>());
+
+            // Act
+            SitecoreLayoutResponse result = await sut.Request(request, "editingHandler");
+
+            // Assert
+            result.Errors.Should().BeEmpty();
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"].Count.Should().Be(5);
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Fields.Values.Count.Should().Be(1);
+            result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Fields["field_1"].Should().BeOfType<JsonSerializedField>();
+            JsonSerializedField? jsonSerialisedField = result?.Content?.Sitecore?.Route?.Placeholders["placeholder_1"][2].As<Component>().Fields["field_1"] as JsonSerializedField;
+            jsonSerialisedField.Should().NotBeNull();
+            EditableField<object>? editableField = jsonSerialisedField?.Read<EditableField<object>>();
+            editableField.Should().NotBeNull();
+            editableField?.OpeningChrome.Should().NotBeNull();
+            editableField?.OpeningChrome?.Attributes["chrometype"].Should().Be("field");
+            editableField?.OpeningChrome?.Attributes["kind"].Should().Be("open");
+            editableField?.OpeningChrome?.Content.Should().Be(@"{""datasource"":{""id"":""datasource_id"",""language"":""en"",""revision"":""revision_1"",""version"":1},""title"":""Text"",""fieldId"":""field_id"",""fieldType"":""Text"",""rawValue"":""field_raw_value""}");
+            editableField?.ClosingChrome.Should().NotBeNull();
+            editableField?.ClosingChrome?.Attributes["chrometype"].Should().Be("field");
+            editableField?.ClosingChrome?.Attributes["kind"].Should().Be("close");
         }
     }
 }

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Sitecore.AspNetCore.SDK.Pages.Tests.csproj
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/Sitecore.AspNetCore.SDK.Pages.Tests.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sitecore.AspNetCore.SDK.LayoutService.Client\Sitecore.AspNetCore.SDK.LayoutService.Client.csproj" />
+    <ProjectReference Include="..\..\src\Sitecore.AspNetCore.SDK.Pages\Sitecore.AspNetCore.SDK.Pages.csproj" />
+    <ProjectReference Include="..\Sitecore.AspNetCore.SDK.AutoFixture\Sitecore.AspNetCore.SDK.AutoFixture.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
@@ -1,0 +1,220 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using AutoFixture;
+using AutoFixture.Idioms;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using NSubstitute;
+using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
+using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
+using Sitecore.AspNetCore.SDK.Pages.TagHelpers;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Interfaces;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
+using Xunit;
+
+namespace Sitecore.AspNetCore.SDK.Pages.Tests.TagHelpers;
+
+public class EditingScriptsTagHelperFixture
+{
+    [ExcludeFromCodeCoverage]
+    public static Action<IFixture> AutoSetup => f =>
+    {
+        ViewContext viewContext = new()
+        {
+            HttpContext = Substitute.For<HttpContext>()
+        };
+
+        FeatureCollection features = new();
+        features[typeof(ISitecoreRenderingContext)] = Substitute.For<ISitecoreRenderingContext>();
+
+        viewContext.HttpContext.Features.Returns(features);
+        f.Inject(viewContext);
+
+        TagHelperOutput tagHelperOutput = new("test", [], (_, _) =>
+        {
+            DefaultTagHelperContent tagHelperContent = new();
+            tagHelperContent.SetHtmlContent(string.Empty);
+            return Task.FromResult<TagHelperContent>(tagHelperContent);
+        });
+
+        f.Inject(tagHelperOutput);
+    };
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Ctor_InvalidArgs_Throws(GuardClauseAssertion guard)
+    {
+        guard.VerifyConstructors<EditingScriptsTagHelper>();
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public async Task ProcessAsync_NoSitecoreContenxt_ExceptionIsThrown(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        ViewContext viewContext = new()
+        {
+            HttpContext = Substitute.For<HttpContext>()
+        };
+        FeatureCollection features = new();
+        viewContext.HttpContext.Features.Returns(features);
+        sut.ViewContext = viewContext;
+
+        // Act
+        Func<Task> act = async () => await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        await act.Should().ThrowAsync<NullReferenceException>();
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public async Task ProcessAsync_NotInEditingMode_OutputIsEmpty(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput, ViewContext viewContext)
+    {
+        // Arrange
+        SitecoreRenderingContext context = new()
+        {
+            Response = new SitecoreLayoutResponse([])
+            {
+                Content = new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Context = new Context
+                        {
+                            IsEditing = false
+                        }
+                    }
+                }
+            }
+        };
+
+        viewContext.HttpContext.SetSitecoreRenderingContext(context);
+        sut.ViewContext = viewContext;
+
+        // Act
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Content.GetContent().Should().BeEmpty();
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public async Task ProcessAsync_IsInEditingMode_ClientScriptsAreOutput(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput, ViewContext viewContext)
+    {
+        // arrange
+        SitecoreRenderingContext context = new()
+        {
+            Response = new SitecoreLayoutResponse([])
+            {
+                Content = new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Context = new Context
+                        {
+                            IsEditing = true
+                        }
+                    },
+                    ContextRawData = "{\"clientScripts\":[\"/assets/js/script1.js\", \"/assets/js/script2.js\", \"/assets/js/script3.js\"]}"
+                }
+            }
+        };
+
+        viewContext.HttpContext.SetSitecoreRenderingContext(context);
+        sut.ViewContext = viewContext;
+
+        // act
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // assert
+        tagHelperOutput.Content.GetContent().Should().Contain("<script type=\"text/javascript\" src=\"/assets/js/script1.js\"></script>");
+        tagHelperOutput.Content.GetContent().Should().Contain("<script type=\"text/javascript\" src=\"/assets/js/script2.js\"></script>");
+        tagHelperOutput.Content.GetContent().Should().Contain("<script type=\"text/javascript\" src=\"/assets/js/script3.js\"></script>");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public async Task ProcessAsync_IsInEditingMode_ItemDataScriptTagIsOutput(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput, ViewContext viewContext)
+    {
+        // arrange
+        SitecoreRenderingContext context = new()
+        {
+            Response = new SitecoreLayoutResponse([])
+            {
+                Content = new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Context = new Context
+                        {
+                            IsEditing = true
+                        }
+                    },
+                    ContextRawData = "{\"clientData\":{\"hrz-canvas-state\": {\"itemId\": \"itemId-1234\",\"itemVersion\": 1,\"siteName\": \"siteName_1234\",\"language\": \"en\",\"deviceId\": \"device_1234\",\"pageMode\": \"NORMAL\",\"variant\": \"variant_1234\"}}}"
+                }
+            }
+        };
+
+        viewContext.HttpContext.SetSitecoreRenderingContext(context);
+        sut.ViewContext = viewContext;
+
+        // act
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // assert
+        string expectedItemDataScriptTag = $@"
+                            <script id=""hrz-canvas-state"" type=""application/json"">
+                                {{
+                                    ""itemId"":""itemId-1234"",
+                                    ""itemVersion"":1,
+                                    ""siteName"":""siteName_1234"",
+                                    ""language"":""en"",
+                                    ""deviceId"":""device_1234"",
+                                    ""pageMode"":""NORMAL"",
+                                    ""variant"":""variant_1234""
+                                }}
+                            </script>
+                        ";
+        tagHelperOutput.Content.GetContent().Should().Contain(expectedItemDataScriptTag);
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public async Task ProcessAsync_IsInEditingMode_CanvasVerificationTokenIsOutput(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput, ViewContext viewContext)
+    {
+        // arrange
+        SitecoreRenderingContext context = new()
+        {
+            Response = new SitecoreLayoutResponse([])
+            {
+                Content = new SitecoreLayoutResponseContent
+                {
+                    Sitecore = new SitecoreData
+                    {
+                        Context = new Context
+                        {
+                            IsEditing = true
+                        }
+                    },
+                    ContextRawData = "{\"clientData\":{\"hrz-canvas-verification-token\":\"token_1234\"}}"
+                }
+            }
+        };
+
+        viewContext.HttpContext.SetSitecoreRenderingContext(context);
+        sut.ViewContext = viewContext;
+
+        // act
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+
+        // assert
+        tagHelperOutput.Content.GetContent().Should().Contain("<script id=\"hrz-canvas-verification-token\" type=\"application/json\">token_1234</script>");
+    }
+}

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RenderingEngineOptionsExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Extensions/RenderingEngineOptionsExtensionsFixture.cs
@@ -224,7 +224,8 @@ public class RenderingEngineOptionsExtensionsFixture
     public void AddModelBoundViewOfTModel_ValidParametersRendererRegistryIsNotEmpty_NewComponentRendererDescriptorIsAddedToTheEndOfTheList(RenderingEngineOptions options, string viewComponentName)
     {
         // Arrange
-        ComponentRendererDescriptor initialDescriptor = new(name => name == "InitialComponent", _ => null!);
+        string componentName = "InitialComponent";
+        ComponentRendererDescriptor initialDescriptor = new(name => name == componentName, _ => null!, componentName);
         options.RendererRegistry.Add(0, initialDescriptor);
 
         // Act

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererDescriptorFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererDescriptorFixture.cs
@@ -30,7 +30,7 @@ public class ComponentRendererDescriptorFixture
     {
         // Arrange
         Func<ComponentRendererDescriptor> act =
-            () => new ComponentRendererDescriptor(null!, null!);
+            () => new ComponentRendererDescriptor(null!, null!, string.Empty);
 
         // Act & Assert
         act.Should().Throw<ArgumentNullException>();
@@ -41,7 +41,8 @@ public class ComponentRendererDescriptorFixture
     public void GetOrCreate_ServiceProviderContainsRendererType_ReturnsRendererType(IServiceProvider services, IComponentRenderer renderer)
     {
         // Arrange
-        ComponentRendererDescriptor sut = new(name => name == "Test", _ => renderer);
+        string componentName = "Test";
+        ComponentRendererDescriptor sut = new(name => name == componentName, _ => renderer, componentName);
 
         // Act
         IComponentRenderer result = sut.GetOrCreate(services);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererFactoryFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/Rendering/ComponentRendererFactoryFixture.cs
@@ -30,7 +30,7 @@ public class ComponentRendererFactoryFixture
         {
             RendererRegistry = new SortedList<int, ComponentRendererDescriptor>
             {
-                { 0, new ComponentRendererDescriptor(name => name == TestComponentName, _ => componentRenderer) }
+                { 0, new ComponentRendererDescriptor(name => name == TestComponentName, _ => componentRenderer, TestComponentName) }
             }
         };
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
@@ -338,6 +338,35 @@ public class DateTagHelperFixture
     }
     #endregion
 
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+       TagHelperContext tagHelperContext,
+       TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        DateTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag;
+        DateField testField = new(_date)
+        {
+            EditableMarkup = Editable,
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.DateModel = testField;
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Content.GetContent().Should().Contain(Editable);
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
+
     private static ModelExpression GetModelExpression(Field model)
     {
         DefaultModelMetadata? modelMetadata = Substitute.For<DefaultModelMetadata>(

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
@@ -12,6 +12,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -35,7 +36,7 @@ public class DateTagHelperFixture
             return Task.FromResult<TagHelperContent>(tagHelperContent);
         });
 
-        f.Register(() => new DateTagHelper());
+        f.Register(() => new DateTagHelper(new EditableChromeRenderer()));
 
         f.Inject(tagHelperContext);
         f.Inject(tagHelperOutput);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -13,6 +13,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Properties;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -38,7 +39,7 @@ public class ImageTagHelperFixture
             return Task.FromResult<TagHelperContent>(tagHelperContent);
         });
 
-        f.Register(() => new ImageTagHelper());
+        f.Register(() => new ImageTagHelper(new EditableChromeRenderer()));
 
         f.Inject(tagHelperContext);
         f.Inject(tagHelperOutput);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -712,6 +712,33 @@ public class ImageTagHelperFixture
     }
     #endregion
 
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+       TagHelperContext tagHelperContext,
+       TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        ImageTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag;
+        ImageField testField = new(new Image { Alt = "Sitecore Logo", Src = "/sitecore/shell/-/media/styleguide/data/media/img/sc_logo.png?iar=0" })
+        {
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.ImageModel = testField;
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
+
     private static ModelExpression GetModelExpression(Field model)
     {
         DefaultModelMetadata? modelMetadata = Substitute.For<DefaultModelMetadata>(

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
@@ -12,6 +12,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Properties;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -38,7 +39,7 @@ public class LinkTagHelperFixture
             return Task.FromResult<TagHelperContent>(tagHelperContent);
         });
 
-        f.Register(() => new LinkTagHelper());
+        f.Register(() => new LinkTagHelper(new EditableChromeRenderer()));
 
         f.Inject(tagHelperContext);
         f.Inject(tagHelperOutput);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/LinkTagHelperFixture.cs
@@ -784,6 +784,34 @@ public class LinkTagHelperFixture
     }
     #endregion
 
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+       TagHelperContext tagHelperContext,
+       TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        LinkTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag;
+        HyperLinkField testField = new(_hyperLink)
+        {
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.LinkModel = testField;
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
+
     private static ModelExpression GetModelExpression(Field model)
     {
         DefaultModelMetadata? modelMetadata = Substitute.For<DefaultModelMetadata>(

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
@@ -12,6 +12,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -37,7 +38,7 @@ public class NumberTagHelperFixture
             return Task.FromResult<TagHelperContent>(tagHelperContent);
         });
 
-        f.Register(() => new NumberTagHelper());
+        f.Register(() => new NumberTagHelper(new EditableChromeRenderer()));
 
         f.Inject(tagHelperContext);
         f.Inject(tagHelperOutput);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/NumberTagHelperFixture.cs
@@ -12,6 +12,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Properties;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
@@ -301,6 +302,33 @@ public class NumberTagHelperFixture
         tagHelperOutput.Content.GetContent().Should().Be(Number1.ToString(sut.NumberFormat, CultureInfo.CreateSpecificCulture(sut.Culture)));
     }
     #endregion
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+   TagHelperContext tagHelperContext,
+   TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        NumberTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.NumberHtmlTag;
+        NumberField testField = new(Number1)
+        {
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.NumberModel = testField;
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
 
     private static ModelExpression GetModelExpression(Field model)
     {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
@@ -12,6 +12,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -706,6 +707,34 @@ public class RichTextTagHelperFixture
     }
 
     #endregion
+
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        RichTextTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.RichTextHtmlTag;
+        RichTextField testField = new(TestHtml, false)
+        {
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.TextModel = testField;
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
 
     private static ModelExpression GetModelExpression(Field model)
     {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
@@ -189,6 +189,34 @@ public class TextFieldTagHelperFixture
         tagHelperOutput.Content.GetContent().Should().Be(TestText);
     }
 
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_RenderingChromesAreNotNull_ChromesAreOutput(
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        IEditableChromeRenderer chromeRenderer = Substitute.For<IEditableChromeRenderer>();
+        TextFieldTagHelper sut = new(chromeRenderer);
+        EditableChrome openingChrome = Substitute.For<EditableChrome>();
+        EditableChrome closingChrome = Substitute.For<EditableChrome>();
+        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.RichTextHtmlTag;
+        TextField testField = new(TestText)
+        {
+            OpeningChrome = openingChrome,
+            ClosingChrome = closingChrome
+        };
+        sut.For = GetModelExpression(testField);
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        chromeRenderer.Received().Render(openingChrome);
+        chromeRenderer.Received().Render(closingChrome);
+    }
+
     private static IEnumerable<object[]> GetModelExpressionTestData()
     {
         yield return [null!, string.Empty];

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
@@ -13,6 +13,7 @@ using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Extensions;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
+using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
 using Xunit;
 
@@ -25,10 +26,14 @@ public class TextFieldTagHelperFixture
     private const string TestHtml = "<p>This is the test text</p>";
     private static readonly string TestMultilineText = $"<p>This is the test text {Environment.NewLine} with line endings.</p>";
 
+    private static EditableChromeRenderer _editableChromeRenderer = null!;
+
     // ReSharper disable once UnusedMember.Global - Used by testing framework
     [ExcludeFromCodeCoverage]
     public static Action<IFixture> AutoSetup => f =>
     {
+        _editableChromeRenderer = f.Freeze<EditableChromeRenderer>();
+
         TagHelperContext tagHelperContext = new(
             [],
             new Dictionary<object, object>(),
@@ -40,7 +45,7 @@ public class TextFieldTagHelperFixture
             return Task.FromResult<TagHelperContent>(tagHelperContent);
         });
 
-        f.Register(() => new TextFieldTagHelper());
+        f.Register(() => new TextFieldTagHelper(_editableChromeRenderer));
 
         f.Inject(tagHelperContext);
         f.Inject(tagHelperOutput);

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/PlaceholderTagHelperFixture.cs
@@ -63,7 +63,7 @@ public class PlaceholderTagHelperFixture
             RendererRegistry = new SortedList<int, ComponentRendererDescriptor>
             {
                 {
-                    0, new ComponentRendererDescriptor(name => name == TestComponentName, _ => componentRenderer)
+                    0, new ComponentRendererDescriptor(name => name == TestComponentName, _ => componentRenderer, TestComponentName)
                 }
             }
         };


### PR DESCRIPTION
This PR adds support for Pages MetaData Editing.

## Description / Motivation
- Introduction of a new Library to be referenced in XMC projects
- Changes required in LayoutService.Client project to introduce concept of Field Chromes, which weren't required previously.
- Tests updated to reflect new and updated code

## Testing

- [x] The Unit & Intergration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).

Closes #17 
