### PR TITLE
Support configuration options for GraphQLHttpClient

### DIFF
--- a/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Extensions/GraphQlConfigurationExtensionsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.GraphQL.Tests/Extensions/GraphQlConfigurationExtensionsFixture.cs
@@ -31,8 +31,10 @@ public class GraphQlConfigurationExtensionsFixture
     [Fact]
     public void AddGraphQlClient_EmptyApiKey_InConfiguration_ThrowsExceptions()
     {
-        Func<IServiceCollection> act =
-            () => Substitute.For<IServiceCollection>().AddGraphQlClient(_ => { });
+        var services = new ServiceCollection();
+        services.AddGraphQlClient(_ => { });
+        var sp = services.BuildServiceProvider();
+        Func<IGraphQLClient> act = () => sp.GetRequiredService<IGraphQLClient>();
         act.Should().Throw<InvalidGraphQlConfigurationException>()
             .WithMessage(Resources.Exception_MissingApiKeyAndContextId);
     }
@@ -41,11 +43,13 @@ public class GraphQlConfigurationExtensionsFixture
     [AutoData]
     public void AddGraphQlClient_EmptyEndpoint_WithApiKey_ThrowsExceptions(string apiKey)
     {
-        Func<IServiceCollection> act =
-            () => Substitute.For<IServiceCollection>().AddGraphQlClient(options =>
-            {
-                options.ApiKey = apiKey;
-            });
+        var services = new ServiceCollection();
+        services.AddGraphQlClient(options =>
+        {
+            options.ApiKey = apiKey;
+        });
+        var sp = services.BuildServiceProvider();
+        Func<IGraphQLClient> act = () => sp.GetRequiredService<IGraphQLClient>();
         act.Should().Throw<InvalidGraphQlConfigurationException>()
             .WithMessage(Resources.Exception_MissingEndpoint);
     }

--- a/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/RequestsFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.LayoutService.Client.Integration.Tests/RequestsFixture.cs
@@ -6,6 +6,7 @@ using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.SystemTextJson;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute.Extensions;
 using Sitecore.AspNetCore.SDK.AutoFixture.Attributes;
 using Sitecore.AspNetCore.SDK.AutoFixture.Mocks;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Extensions;
@@ -40,13 +41,7 @@ public class RequestsFixture
         };
         message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/graphql+json");
         result.Responses.Push(message);
-        ServiceDescriptor gqlClient = services.Single(s => s.ServiceKey?.ToString() == handlerName);
-        GraphQLHttpClientOptions options = ((GraphQLHttpClient)gqlClient.KeyedImplementationInstance!).Options;
-        options.HttpMessageHandler = result;
-        services.RemoveAllKeyed<IGraphQLClient>(handlerName);
-        services.AddKeyedSingleton<IGraphQLClient>(handlerName, new GraphQLHttpClient(
-            options,
-            new SystemTextJsonSerializer()));
+        services.Configure<GraphQLHttpClientOptions>(options => options.HttpMessageHandler = result);
 
         // Build and grab the sut
         IServiceProvider provider = services.BuildServiceProvider();


### PR DESCRIPTION
Use SitecoreGraphQlClientOptions for GraphQLHttpClient and support Configure

## Description / Motivation
With this change it is possible to configure the ``GraphQLClient`` with Configure in DependencyInjection.

e.g. in a ``WebApplicationFactory`` call ```services.Configure<SitecoreGraphQlClientOptions>(cfg => cfg.HttpMessageHandler = _mockClientHandler);```

The value is already consumed through dependency injection in eg. ``GraphQlSiteInfoService``

The consequence is that any validation error are thrown upon first time the ``GraphQLHttpClient`` is resolved instead of on initial call to ``AddGraphQlClient`` during application setup.


## Testing

- [x] The Unit & Intergration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
