### PR TITLE
Changed text based TagHelpers to rendering Chromes with internal span not div

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/RichTextTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/RichTextTagHelper.cs
@@ -55,7 +55,7 @@ public class RichTextTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelp
         if (Editable && richTextField.OpeningChrome != null)
         {
             html += _chromeRenderer.Render(richTextField.OpeningChrome);
-            html += "<div>";
+            html += "<span>";
         }
 
         bool outputEditableMarkup = Editable && !string.IsNullOrEmpty(richTextField.EditableMarkup);
@@ -65,7 +65,7 @@ public class RichTextTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelp
 
         if (Editable && richTextField.ClosingChrome != null)
         {
-            html += "</div>";
+            html += "</span>";
             html += _chromeRenderer.Render(richTextField.ClosingChrome);
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/TextFieldTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/TextFieldTagHelper.cs
@@ -51,7 +51,7 @@ public partial class TextFieldTagHelper(IEditableChromeRenderer chromeRenderer) 
         if (Editable && field.OpeningChrome != null)
         {
             html += _chromeRenderer.Render(field.OpeningChrome);
-            html += "<div>";
+            html += "<span>";
             isHtml = true;
         }
 
@@ -67,7 +67,7 @@ public partial class TextFieldTagHelper(IEditableChromeRenderer chromeRenderer) 
 
         if (Editable && field.ClosingChrome != null)
         {
-            html += "</div>";
+            html += "</span>";
             html += _chromeRenderer.Render(field.ClosingChrome);
         }
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
@@ -1,4 +1,6 @@
-﻿using AutoFixture;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using AutoFixture;
 using AutoFixture.Idioms;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -12,9 +14,6 @@ using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text.Encodings.Web;
 using Xunit;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.Tests.TagHelpers.Fields;

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/RichTextTagHelperFixture.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using AutoFixture;
+﻿using AutoFixture;
 using AutoFixture.Idioms;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -14,6 +12,9 @@ using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 using Sitecore.AspNetCore.SDK.RenderingEngine.TagHelpers.Fields;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Encodings.Web;
 using Xunit;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.Tests.TagHelpers.Fields;
@@ -733,6 +734,7 @@ public class RichTextTagHelperFixture
         // Assert
         chromeRenderer.Received().Render(openingChrome);
         chromeRenderer.Received().Render(closingChrome);
+        tagHelperOutput.Content.GetContent().Should().Be($"{chromeRenderer.Render(openingChrome)}<span>{TestHtml}</span>{chromeRenderer.Render(closingChrome)}");
     }
 
     private static ModelExpression GetModelExpression(Field model)

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/TextFieldTagHelperFixture.cs
@@ -214,6 +214,7 @@ public class TextFieldTagHelperFixture
         // Assert
         chromeRenderer.Received().Render(openingChrome);
         chromeRenderer.Received().Render(closingChrome);
+        tagHelperOutput.Content.GetContent().Should().Be($"{chromeRenderer.Render(openingChrome)}<span>{TestText}</span>{chromeRenderer.Render(closingChrome)}");
     }
 
     private static IEnumerable<object[]> GetModelExpressionTestData()


### PR DESCRIPTION
This fixes the bug where Text based TagHelpers can't render inside of a `p` tag, causing all of MetaData editing to break.

This aligns with the JSS approach of using a `span` tag instead.

I also introduced a new `Assert` to the appropriate UnitTests as that tag insertion wasn't being tested currently.

## Testing

- [x] The Unit & Intergration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).

Closes #39 
