### PR TITLE
Enable SrcSet support with two different input formats for Image tag helper

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -210,7 +210,7 @@ public static partial class SitecoreFieldExtensions
                 parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }
 
-            return original.Substring(0, queryIndex);
+            return original[..queryIndex];
         }
 
         return original;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -150,11 +150,9 @@ public static partial class SitecoreFieldExtensions
             return urlStr;
         }
 
-        string url = urlStr;
-
         // Parse existing query parameters and build merged parameters dictionary
         Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        url = ParseUrlParams(url, mergedParams);
+        string url = ParseUrlParams(urlStr, mergedParams);
 
         // Add new parameters (these will override existing ones)
         AddParametersToResult(mergedParams, parameters, skipNullValues: true);

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -176,28 +176,27 @@ public static partial class SitecoreFieldExtensions
     /// <returns>The URL without query parameters.</returns>
     private static string ParseUrlParams(string url, Dictionary<string, object?> parameters)
     {
-        if (url.Contains('?'))
+        if (string.IsNullOrEmpty(url))
         {
-            string[] parts = url.Split('?', 2);
-            string cleanUrl = parts[0];
-            string queryString = parts[1];
-
-            string[] paramPairs = queryString.Split('&');
-            foreach (string paramPair in paramPairs)
-            {
-                string[] keyValue = paramPair.Split('=', 2);
-                if (keyValue.Length == 2)
-                {
-                    string key = HttpUtility.UrlDecode(keyValue[0]);
-                    string value = HttpUtility.UrlDecode(keyValue[1]);
-                    parameters[key] = value;
-                }
-            }
-
-            return cleanUrl;
+            return url;
         }
 
-        return url;
+        int queryIndex = url.IndexOf('?');
+        if (queryIndex < 0)
+        {
+            return url;
+        }
+
+        string cleanUrl = url.Substring(0, queryIndex);
+        string queryString = url.Substring(queryIndex);
+
+        Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(queryString);
+        foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
+        {
+            parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
+        }
+
+        return cleanUrl;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -186,40 +186,21 @@ public static partial class SitecoreFieldExtensions
             return string.Empty;
         }
 
-        string urlWithoutQuery;
-        string? query = null;
+        string original = uri.OriginalString;
+        int queryIndex = original.IndexOf('?');
 
-        if (uri.IsAbsoluteUri)
+        if (queryIndex >= 0)
         {
-            urlWithoutQuery = uri.GetLeftPart(UriPartial.Path);
-            query = uri.Query;
-        }
-        else
-        {
-            // For relative URIs, manually split on '?'
-            var original = uri.OriginalString;
-            int idx = original.IndexOf('?');
-            if (idx >= 0)
-            {
-                urlWithoutQuery = original.Substring(0, idx);
-                query = original.Substring(idx);
-            }
-            else
-            {
-                urlWithoutQuery = original;
-            }
-        }
-
-        if (!string.IsNullOrEmpty(query))
-        {
+            string query = original.Substring(queryIndex);
             var parsedQuery = QueryHelpers.ParseQuery(query);
-            foreach (KeyValuePair<string, StringValues> kvp in parsedQuery)
+            foreach (var kvp in parsedQuery)
             {
                 parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }
+            return original.Substring(0, queryIndex);
         }
 
-        return urlWithoutQuery;
+        return original;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -97,13 +97,12 @@ public static partial class SitecoreFieldExtensions
         }
         else
         {
-            PropertyInfo[] properties = parameters.GetType().GetProperties();
-            foreach (PropertyInfo prop in properties)
+            RouteValueDictionary routeValues = new RouteValueDictionary(parameters);
+            foreach (KeyValuePair<string, object?> kvp in routeValues)
             {
-                object? value = prop.GetValue(parameters);
-                if (!skipNullValues || value != null)
+                if (!skipNullValues || kvp.Value != null)
                 {
-                    result[prop.Name] = value;
+                    result[kvp.Key] = kvp.Value;
                 }
             }
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 
 namespace Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
@@ -212,7 +213,7 @@ public static partial class SitecoreFieldExtensions
         if (!string.IsNullOrEmpty(query))
         {
             var parsedQuery = QueryHelpers.ParseQuery(query);
-            foreach (var kvp in parsedQuery)
+            foreach (KeyValuePair<string, StringValues> kvp in parsedQuery)
             {
                 parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -32,27 +32,6 @@ public static partial class SitecoreFieldExtensions
     }
 
     /// <summary>
-    /// Gets modified URL string to Sitecore media item with merged parameters.
-    /// </summary>
-    /// <param name="imageField">The image field.</param>
-    /// <param name="imageParams">Base image parameters.</param>
-    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
-    /// <returns>Media item URL.</returns>
-    public static string? GetMediaLink(this ImageField imageField, object? imageParams, object? srcSetParams)
-    {
-        ArgumentNullException.ThrowIfNull(imageField);
-        string? urlStr = imageField.Value.Src;
-
-        if (urlStr == null)
-        {
-            return null;
-        }
-
-        Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
-    }
-
-    /// <summary>
     /// Gets modified URL string to Sitecore media item for srcSet.
     /// This method preserves existing URL parameters and merges them with new ones.
     /// </summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -62,7 +62,7 @@ public static partial class SitecoreFieldExtensions
     /// <returns>Merged parameters as dictionary.</returns>
     private static Dictionary<string, object?> MergeParameters(object? imageParams, object? srcSetParams)
     {
-        Dictionary<string, object?> result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, object?> result = new(StringComparer.OrdinalIgnoreCase);
 
         // Add base parameters first
         AddParametersToResult(result, imageParams);
@@ -98,7 +98,7 @@ public static partial class SitecoreFieldExtensions
         }
         else
         {
-            RouteValueDictionary routeValues = new RouteValueDictionary(parameters);
+            RouteValueDictionary routeValues = new(parameters);
             foreach (KeyValuePair<string, object?> kvp in routeValues)
             {
                 if (!skipNullValues || kvp.Value != null)
@@ -151,7 +151,7 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Parse existing query parameters and build merged parameters dictionary
-        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, object?> mergedParams = new(StringComparer.OrdinalIgnoreCase);
         Uri? uri = null;
         if (!string.IsNullOrEmpty(urlStr))
         {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -61,7 +61,7 @@ public static partial class SitecoreFieldExtensions
     /// <returns>Merged parameters as dictionary.</returns>
     private static Dictionary<string, object?> MergeParameters(object? baseParams, object? overrideParams)
     {
-        Dictionary<string, object?> result = new Dictionary<string, object?>();
+        Dictionary<string, object?> result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         // Add base parameters first
         if (baseParams != null)
@@ -157,7 +157,7 @@ public static partial class SitecoreFieldExtensions
         string url = urlStr;
 
         // Parse existing query parameters
-        Dictionary<string, string> existingParams = new Dictionary<string, string>();
+        Dictionary<string, string> existingParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         if (url.Contains('?'))
         {
             string[] parts = url.Split('?', 2);
@@ -178,7 +178,7 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Merge with new parameters (new parameters override existing ones)
-        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>();
+        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         // Add existing parameters first
         foreach (KeyValuePair<string, string> kvp in existingParams)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -30,6 +30,80 @@ public static partial class SitecoreFieldExtensions
     }
 
     /// <summary>
+    /// Gets modified URL string to Sitecore media item with merged parameters.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLink(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUri(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Merges base parameters with override parameters.
+    /// </summary>
+    /// <param name="baseParams">Base parameters.</param>
+    /// <param name="overrideParams">Override parameters that take precedence.</param>
+    /// <returns>Merged parameters as dictionary.</returns>
+    private static Dictionary<string, object?> MergeParameters(object? baseParams, object? overrideParams)
+    {
+        var result = new Dictionary<string, object?>();
+
+        // Add base parameters first
+        if (baseParams != null)
+        {
+            if (baseParams is Dictionary<string, object> baseDict)
+            {
+                foreach (var kvp in baseDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var baseProps = baseParams.GetType().GetProperties();
+                foreach (var prop in baseProps)
+                {
+                    result[prop.Name] = prop.GetValue(baseParams);
+                }
+            }
+        }
+
+        // Override with srcSet parameters
+        if (overrideParams != null)
+        {
+            if (overrideParams is Dictionary<string, object> overrideDict)
+            {
+                foreach (var kvp in overrideDict)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            else
+            {
+                var overrideProps = overrideParams.GetType().GetProperties();
+                foreach (var prop in overrideProps)
+                {
+                    result[prop.Name] = prop.GetValue(overrideParams);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Gets URL to Sitecore media item.
     /// </summary>
     /// <param name="url">The image URL.</param>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -203,7 +203,7 @@ public static partial class SitecoreFieldExtensions
 
         if (queryIndex >= 0)
         {
-            string query = original.Substring(queryIndex);
+            string query = original[queryIndex..];
             Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(query);
             foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -154,14 +154,7 @@ public static partial class SitecoreFieldExtensions
 
         // Parse existing query parameters and build merged parameters dictionary
         Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        if (url.Contains('?'))
-        {
-            string[] parts = url.Split('?', 2);
-            url = parts[0];
-            string queryString = parts[1];
-
-            ParseUrlParams(queryString, mergedParams);
-        }
+        url = ParseUrlParams(url, mergedParams);
 
         // Add new parameters (these will override existing ones)
         AddParametersToResult(mergedParams, parameters, skipNullValues: true);
@@ -181,21 +174,33 @@ public static partial class SitecoreFieldExtensions
     /// <summary>
     /// Parses URL query string parameters and adds them to the provided dictionary.
     /// </summary>
-    /// <param name="queryString">The query string to parse.</param>
+    /// <param name="url">The full URL with potential query parameters.</param>
     /// <param name="parameters">The dictionary to add parsed parameters to.</param>
-    private static void ParseUrlParams(string queryString, Dictionary<string, object?> parameters)
+    /// <returns>The URL without query parameters.</returns>
+    private static string ParseUrlParams(string url, Dictionary<string, object?> parameters)
     {
-        string[] paramPairs = queryString.Split('&');
-        foreach (string paramPair in paramPairs)
+        if (url.Contains('?'))
         {
-            string[] keyValue = paramPair.Split('=', 2);
-            if (keyValue.Length == 2)
+            string[] parts = url.Split('?', 2);
+            string cleanUrl = parts[0];
+            string queryString = parts[1];
+
+            string[] paramPairs = queryString.Split('&');
+            foreach (string paramPair in paramPairs)
             {
-                string key = HttpUtility.UrlDecode(keyValue[0]);
-                string value = HttpUtility.UrlDecode(keyValue[1]);
-                parameters[key] = value;
+                string[] keyValue = paramPair.Split('=', 2);
+                if (keyValue.Length == 2)
+                {
+                    string key = HttpUtility.UrlDecode(keyValue[0]);
+                    string value = HttpUtility.UrlDecode(keyValue[1]);
+                    parameters[key] = value;
+                }
             }
+
+            return cleanUrl;
         }
+
+        return url;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -156,8 +156,8 @@ public static partial class SitecoreFieldExtensions
 
         string url = urlStr;
 
-        // Parse existing query parameters
-        Dictionary<string, string> existingParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Parse existing query parameters and build merged parameters dictionary
+        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
         if (url.Contains('?'))
         {
             string[] parts = url.Split('?', 2);
@@ -172,18 +172,9 @@ public static partial class SitecoreFieldExtensions
                 {
                     string key = HttpUtility.UrlDecode(keyValue[0]);
                     string value = HttpUtility.UrlDecode(keyValue[1]);
-                    existingParams[key] = value;
+                    mergedParams[key] = value;
                 }
             }
-        }
-
-        // Merge with new parameters (new parameters override existing ones)
-        Dictionary<string, object?> mergedParams = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-
-        // Add existing parameters first
-        foreach (KeyValuePair<string, string> kvp in existingParams)
-        {
-            mergedParams[kvp.Key] = kvp.Value;
         }
 
         // Add new parameters (these will override existing ones)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -130,14 +130,7 @@ public static partial class SitecoreFieldExtensions
             }
         }
 
-        // TODO Review hardcoded matching and replacement
-        Match match = MediaUrlPrefixRegex().Match(url);
-        if (match.Success)
-        {
-            url = url.Replace(match.Value, $"/{match.Groups[1]}/jssmedia/", StringComparison.InvariantCulture);
-        }
-
-        return url;
+        return ApplyJssMediaUrlPrefix(url);
     }
 
     /// <summary>
@@ -210,6 +203,16 @@ public static partial class SitecoreFieldExtensions
             }
         }
 
+        return ApplyJssMediaUrlPrefix(url);
+    }
+
+    /// <summary>
+    /// Applies JSS media URL prefix replacement to the given URL.
+    /// </summary>
+    /// <param name="url">The URL to transform.</param>
+    /// <returns>The URL with JSS media prefix applied if applicable.</returns>
+    private static string ApplyJssMediaUrlPrefix(string url)
+    {
         // TODO Review hardcoded matching and replacement
         Match match = MediaUrlPrefixRegex().Match(url);
         if (match.Success)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Web;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
@@ -47,7 +48,29 @@ public static partial class SitecoreFieldExtensions
         }
 
         var mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUri(urlStr, mergedParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item for srcSet with parameter preservation.
+    /// This method preserves critical Sitecore parameters needed for proper image processing.
+    /// </summary>
+    /// <param name="imageField">The image field.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that override imageParams.</param>
+    /// <returns>Media item URL.</returns>
+    public static string? GetMediaLinkForSrcSet(this ImageField imageField, object? imageParams, object? srcSetParams)
+    {
+        ArgumentNullException.ThrowIfNull(imageField);
+        string? urlStr = imageField.Value.Src;
+
+        if (urlStr == null)
+        {
+            return null;
+        }
+
+        var mergedParams = MergeParameters(imageParams, srcSetParams);
+        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
     }
 
     /// <summary>
@@ -97,6 +120,82 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[prop.Name] = prop.GetValue(overrideParams);
                 }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets modified URL string to Sitecore media item with parameter preservation.
+    /// This preserves existing query parameters while adding new ones.
+    /// </summary>
+    /// <param name="url">Media item source URL.</param>
+    /// <param name="parameters">Additional parameters to merge with existing ones.</param>
+    /// <returns>Media item URL with preserved and merged parameters.</returns>
+    private static string GetSitecoreMediaUriWithPreservation(string url, object? parameters)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return url;
+        }
+
+        // Parse the existing URL to separate base URL and query string
+        var uri = new Uri(url);
+        var baseUrl = uri.GetLeftPart(UriPartial.Path);
+        var existingQuery = HttpUtility.ParseQueryString(uri.Query);
+
+        // Convert parameters to dictionary and merge with existing query parameters
+        var paramDict = ConvertToStringDictionary(parameters);
+        if (paramDict != null)
+        {
+            foreach (var param in paramDict)
+            {
+                existingQuery[param.Key] = param.Value;
+            }
+        }
+
+        // Apply the media URL prefix transformation (jssmedia replacement)
+        var finalBaseUrl = baseUrl;
+        Match match = MediaUrlPrefixRegex().Match(finalBaseUrl);
+        if (match.Success)
+        {
+            finalBaseUrl = finalBaseUrl.Replace(match.Value, $"/{match.Groups[1]}/jssmedia/", StringComparison.InvariantCulture);
+        }
+
+        // Build the final URL with merged parameters
+        var queryString = existingQuery.ToString();
+        return string.IsNullOrEmpty(queryString) ? finalBaseUrl : $"{finalBaseUrl}?{queryString}";
+    }
+
+    /// <summary>
+    /// Converts an object to a string dictionary.
+    /// </summary>
+    /// <param name="obj">The object to convert.</param>
+    /// <returns>Dictionary representation of the object.</returns>
+    private static Dictionary<string, string>? ConvertToStringDictionary(object? obj)
+    {
+        if (obj == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+
+        if (obj is Dictionary<string, object> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                result[kvp.Key] = kvp.Value?.ToString() ?? string.Empty;
+            }
+        }
+        else
+        {
+            var props = obj.GetType().GetProperties();
+            foreach (var prop in props)
+            {
+                var value = prop.GetValue(obj);
+                result[prop.Name] = value?.ToString() ?? string.Empty;
             }
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -81,31 +81,23 @@ public static partial class SitecoreFieldExtensions
     /// <param name="skipNullValues">Whether to skip null values when adding parameters.</param>
     private static void AddParametersToResult(Dictionary<string, object?> result, object? parameters, bool skipNullValues = false)
     {
-        if (parameters == null)
+        switch (parameters)
         {
-            return;
-        }
-
-        if (parameters is Dictionary<string, object?> paramDict)
-        {
-            foreach (KeyValuePair<string, object?> kvp in paramDict)
-            {
-                if (!skipNullValues || kvp.Value != null)
+            case null:
+                break;
+            case Dictionary<string, object?> paramDict:
+                foreach (KeyValuePair<string, object?> kvp in paramDict.Where(kvp => !skipNullValues || kvp.Value != null))
                 {
                     result[kvp.Key] = kvp.Value;
                 }
-            }
-        }
-        else
-        {
-            RouteValueDictionary routeValues = new(parameters);
-            foreach (KeyValuePair<string, object?> kvp in routeValues)
-            {
-                if (!skipNullValues || kvp.Value != null)
+                break;
+            default:
+                RouteValueDictionary routeValues = new(parameters);
+                foreach (KeyValuePair<string, object?> kvp in routeValues.Where(kvp => !skipNullValues || kvp.Value != null))
                 {
                     result[kvp.Key] = kvp.Value;
                 }
-            }
+                break;
         }
     }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -141,9 +141,9 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Parse the existing URL to separate base URL and query string
-        var uri = new Uri(url);
+        var uri = new Uri(url, UriKind.RelativeOrAbsolute);
         var baseUrl = uri.GetLeftPart(UriPartial.Path);
-        var existingQuery = HttpUtility.ParseQueryString(uri.Query);
+        var existingQuery = QueryHelpers.ParseQuery(uri.Query);
 
         // Convert parameters to dictionary and merge with existing query parameters
         var paramDict = ConvertToStringDictionary(parameters);
@@ -151,6 +151,7 @@ public static partial class SitecoreFieldExtensions
         {
             foreach (var param in paramDict)
             {
+                // QueryHelpers.ParseQuery returns StringValues, so we need to handle this properly
                 existingQuery[param.Key] = param.Value;
             }
         }
@@ -164,8 +165,8 @@ public static partial class SitecoreFieldExtensions
         }
 
         // Build the final URL with merged parameters
-        var queryString = existingQuery.ToString();
-        return string.IsNullOrEmpty(queryString) ? finalBaseUrl : $"{finalBaseUrl}?{queryString}";
+        var queryString = QueryHelpers.AddQueryString(string.Empty, existingQuery.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString()));
+        return queryString.StartsWith("?") ? $"{finalBaseUrl}{queryString}" : finalBaseUrl;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -90,6 +90,7 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[kvp.Key] = kvp.Value;
                 }
+
                 break;
             default:
                 RouteValueDictionary routeValues = new(parameters);
@@ -97,6 +98,7 @@ public static partial class SitecoreFieldExtensions
                 {
                     result[kvp.Key] = kvp.Value;
                 }
+
                 break;
         }
     }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -196,26 +196,24 @@ public static partial class SitecoreFieldExtensions
 
             return url;
         }
-        else
+
+        // For relative URIs, accessing Uri.Query throws InvalidOperationException, so we use string manipulation
+        string original = uri.OriginalString;
+        int queryIndex = original.IndexOf('?');
+
+        if (queryIndex >= 0)
         {
-            // For relative URIs, accessing Uri.Query throws InvalidOperationException, so we use string manipulation
-            string original = uri.OriginalString;
-            int queryIndex = original.IndexOf('?');
-
-            if (queryIndex >= 0)
+            string query = original.Substring(queryIndex);
+            Dictionary<string, Microsoft.Extensions.Primitives.StringValues> parsedQuery = QueryHelpers.ParseQuery(query);
+            foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in parsedQuery)
             {
-                string query = original.Substring(queryIndex);
-                var parsedQuery = QueryHelpers.ParseQuery(query);
-                foreach (var kvp in parsedQuery)
-                {
-                    parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
-                }
-
-                return original.Substring(0, queryIndex);
+                parameters[kvp.Key] = kvp.Value.Count > 0 ? kvp.Value[0] : null;
             }
 
-            return original;
+            return original.Substring(0, queryIndex);
         }
+
+        return original;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -160,17 +160,7 @@ public static partial class SitecoreFieldExtensions
             url = parts[0];
             string queryString = parts[1];
 
-            string[] paramPairs = queryString.Split('&');
-            foreach (string paramPair in paramPairs)
-            {
-                string[] keyValue = paramPair.Split('=', 2);
-                if (keyValue.Length == 2)
-                {
-                    string key = HttpUtility.UrlDecode(keyValue[0]);
-                    string value = HttpUtility.UrlDecode(keyValue[1]);
-                    mergedParams[key] = value;
-                }
-            }
+            ParseUrlParams(queryString, mergedParams);
         }
 
         // Add new parameters (these will override existing ones)
@@ -186,6 +176,26 @@ public static partial class SitecoreFieldExtensions
         }
 
         return ApplyJssMediaUrlPrefix(url);
+    }
+
+    /// <summary>
+    /// Parses URL query string parameters and adds them to the provided dictionary.
+    /// </summary>
+    /// <param name="queryString">The query string to parse.</param>
+    /// <param name="parameters">The dictionary to add parsed parameters to.</param>
+    private static void ParseUrlParams(string queryString, Dictionary<string, object?> parameters)
+    {
+        string[] paramPairs = queryString.Split('&');
+        foreach (string paramPair in paramPairs)
+        {
+            string[] keyValue = paramPair.Split('=', 2);
+            if (keyValue.Length == 2)
+            {
+                string key = HttpUtility.UrlDecode(keyValue[0]);
+                string value = HttpUtility.UrlDecode(keyValue[1]);
+                parameters[key] = value;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -23,12 +23,13 @@ public static partial class SitecoreFieldExtensions
         ArgumentNullException.ThrowIfNull(imageField);
         string? urlStr = imageField.Value.Src;
 
-        if (urlStr == null)
+        string? result = null;
+        if (urlStr != null)
         {
-            return null;
+            result = GetSitecoreMediaUri(urlStr, imageParams);
         }
 
-        return GetSitecoreMediaUri(urlStr, imageParams);
+        return result;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -56,17 +56,17 @@ public static partial class SitecoreFieldExtensions
     /// <summary>
     /// Merges base parameters with override parameters.
     /// </summary>
-    /// <param name="baseParams">Base parameters.</param>
-    /// <param name="overrideParams">Override parameters that take precedence.</param>
+    /// <param name="imageParams">Base image parameters.</param>
+    /// <param name="srcSetParams">SrcSet specific parameters that take precedence.</param>
     /// <returns>Merged parameters as dictionary.</returns>
-    private static Dictionary<string, object?> MergeParameters(object? baseParams, object? overrideParams)
+    private static Dictionary<string, object?> MergeParameters(object? imageParams, object? srcSetParams)
     {
         Dictionary<string, object?> result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         // Add base parameters first
-        if (baseParams != null)
+        if (imageParams != null)
         {
-            if (baseParams is Dictionary<string, object> baseDict)
+            if (imageParams is Dictionary<string, object> baseDict)
             {
                 foreach (KeyValuePair<string, object> kvp in baseDict)
                 {
@@ -75,18 +75,18 @@ public static partial class SitecoreFieldExtensions
             }
             else
             {
-                PropertyInfo[] baseProps = baseParams.GetType().GetProperties();
+                PropertyInfo[] baseProps = imageParams.GetType().GetProperties();
                 foreach (PropertyInfo prop in baseProps)
                 {
-                    result[prop.Name] = prop.GetValue(baseParams);
+                    result[prop.Name] = prop.GetValue(imageParams);
                 }
             }
         }
 
         // Override with srcSet parameters
-        if (overrideParams != null)
+        if (srcSetParams != null)
         {
-            if (overrideParams is Dictionary<string, object> overrideDict)
+            if (srcSetParams is Dictionary<string, object> overrideDict)
             {
                 foreach (KeyValuePair<string, object> kvp in overrideDict)
                 {
@@ -95,10 +95,10 @@ public static partial class SitecoreFieldExtensions
             }
             else
             {
-                PropertyInfo[] overrideProps = overrideParams.GetType().GetProperties();
+                PropertyInfo[] overrideProps = srcSetParams.GetType().GetProperties();
                 foreach (PropertyInfo prop in overrideProps)
                 {
-                    result[prop.Name] = prop.GetValue(overrideParams);
+                    result[prop.Name] = prop.GetValue(srcSetParams);
                 }
             }
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -138,11 +138,15 @@ public static partial class SitecoreFieldExtensions
     /// <param name="urlStr">The URL string.</param>
     /// <param name="parameters">Parameters to merge.</param>
     /// <returns>Modified URL string.</returns>
-    private static string GetSitecoreMediaUriWithPreservation(string urlStr, object? parameters)
+    private static string? GetSitecoreMediaUriWithPreservation(string? urlStr, object? parameters)
     {
-        string url;
+        string? url;
 
-        if (string.IsNullOrEmpty(urlStr))
+        if (urlStr == null)
+        {
+            url = null;
+        }
+        else if (string.IsNullOrEmpty(urlStr))
         {
             url = string.Empty;
         }
@@ -167,7 +171,7 @@ public static partial class SitecoreFieldExtensions
             }
         }
 
-        return ApplyJssMediaUrlPrefix(url);
+        return url == null ? null : ApplyJssMediaUrlPrefix(url);
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -142,36 +142,39 @@ public static partial class SitecoreFieldExtensions
     {
         string? url;
 
-        if (urlStr == null)
+        if (string.IsNullOrEmpty(urlStr))
         {
-            url = null;
-        }
-        else if (string.IsNullOrEmpty(urlStr))
-        {
-            url = string.Empty;
+            url = urlStr;
         }
         else
         {
             // Parse existing query parameters and build merged parameters dictionary
             Dictionary<string, object?> mergedParams = new(StringComparer.OrdinalIgnoreCase);
-            Uri.TryCreate(urlStr, UriKind.RelativeOrAbsolute, out Uri? uri);
 
-            url = ParseUrlParams(uri, mergedParams);
-
-            // Add new parameters (these will override existing ones)
-            AddParametersToResult(mergedParams, parameters, skipNullValues: true);
-
-            // Add query parameters
-            foreach (KeyValuePair<string, object?> kvp in mergedParams)
+            if (!Uri.TryCreate(urlStr, UriKind.RelativeOrAbsolute, out Uri? uri))
             {
-                if (kvp.Value != null)
+                url = urlStr;
+            }
+            else
+            {
+                url = ParseUrlParams(uri, mergedParams);
+
+                // Add new parameters (these will override existing ones)
+                AddParametersToResult(mergedParams, parameters, skipNullValues: true);
+
+                // Add query parameters
+                foreach (KeyValuePair<string, object?> kvp in mergedParams)
                 {
-                    url = QueryHelpers.AddQueryString(url, kvp.Key, kvp.Value.ToString() ?? string.Empty);
+                    if (kvp.Value != null)
+                    {
+                        url = QueryHelpers.AddQueryString(url, kvp.Key, kvp.Value.ToString() ?? string.Empty);
+                    }
                 }
             }
         }
 
-        return url == null ? null : ApplyJssMediaUrlPrefix(url);
+        string? result = url == null ? null : ApplyJssMediaUrlPrefix(url);
+        return result;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/Extensions/SitecoreFieldExtensions.cs
@@ -45,13 +45,14 @@ public static partial class SitecoreFieldExtensions
         ArgumentNullException.ThrowIfNull(imageField);
         string? urlStr = imageField.Value.Src;
 
-        if (urlStr == null)
+        string? result = null;
+        if (urlStr != null)
         {
-            return null;
+            Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
+            result = GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
         }
 
-        Dictionary<string, object?> mergedParams = MergeParameters(imageParams, srcSetParams);
-        return GetSitecoreMediaUriWithPreservation(urlStr, mergedParams);
+        return result;
     }
 
     /// <summary>

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -171,6 +171,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         }
     }
 
+    private static string? TryParseParameter(object parameters, string paramName, PropertyInfo[] properties)
+    {
+        PropertyInfo? prop = properties.FirstOrDefault(p => p.Name.Equals(paramName, StringComparison.OrdinalIgnoreCase));
+        return prop?.GetValue(parameters)?.ToString();
+    }
+
     private static string? GetWidthDescriptor(object? parameters)
     {
         if (parameters == null)
@@ -205,35 +211,10 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             PropertyInfo[] properties = parameters.GetType().GetProperties();
 
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            PropertyInfo? wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
-            if (wProp != null)
-            {
-                width = wProp.GetValue(parameters)?.ToString();
-            }
-            else
-            {
-                PropertyInfo? mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
-                if (mwProp != null)
-                {
-                    width = mwProp.GetValue(parameters)?.ToString();
-                }
-                else
-                {
-                    PropertyInfo? widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
-                    if (widthProp != null)
-                    {
-                        width = widthProp.GetValue(parameters)?.ToString();
-                    }
-                    else
-                    {
-                        PropertyInfo? maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
-                        if (maxWidthProp != null)
-                        {
-                            width = maxWidthProp.GetValue(parameters)?.ToString();
-                        }
-                    }
-                }
-            }
+            width = TryParseParameter(parameters, "w", properties)
+                ?? TryParseParameter(parameters, "mw", properties)
+                ?? TryParseParameter(parameters, "width", properties)
+                ?? TryParseParameter(parameters, "maxWidth", properties);
         }
 
         // Validate width is positive

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -34,8 +34,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private const string SizesAttribute = "sizes";
     private readonly IEditableChromeRenderer _chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
-    private static string? GetWidthDescriptor(object parameters)
+    private static string? GetWidthDescriptor(object? parameters)
     {
+        if (parameters == null)
+        {
+            return null;
+        }
+
         string? width = null;
 
         // Handle Dictionary<string, object>
@@ -50,13 +55,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             {
                 width = mwValue?.ToString();
             }
-            else if (dictionary.TryGetValue("width", out object? widthValue))
+            else if (dictionary.TryGetValue("width", out object? widthObj))
             {
-                width = widthValue?.ToString();
+                width = widthObj?.ToString();
             }
-            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthValue))
+            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthObj))
             {
-                width = maxWidthValue?.ToString();
+                width = maxWidthObj?.ToString();
             }
         }
         else
@@ -94,6 +99,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                     }
                 }
             }
+        }
+
+        // Validate width is positive
+        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
+        {
+            return null;
         }
 
         return width != null ? $"{width}w" : null;
@@ -408,6 +419,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         foreach (object srcSetItem in parsedSrcSet)
         {
+            // Skip null items
+            if (srcSetItem == null)
+            {
+                continue;
+            }
+
             // Get width descriptor first to check if this entry should be included
             string? descriptor = GetWidthDescriptor(srcSetItem);
             if (descriptor == null)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -181,19 +181,19 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
         string? width = null;
-        if (dictionary.TryGetValue("w", out var wValue))
+        if (dictionary.TryGetValue("w", out object? wValue))
         {
             width = wValue.ToString();
         }
-        else if (dictionary.TryGetValue("mw", out var mwValue))
+        else if (dictionary.TryGetValue("mw", out object? mwValue))
         {
             width = mwValue.ToString();
         }
-        else if (dictionary.TryGetValue("width", out var widthValue))
+        else if (dictionary.TryGetValue("width", out object? widthValue))
         {
             width = widthValue.ToString();
         }
-        else if (dictionary.TryGetValue("maxWidth", out var maxWidthValue))
+        else if (dictionary.TryGetValue("maxWidth", out object? maxWidthValue))
         {
             width = maxWidthValue.ToString();
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -36,7 +36,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private static string? GetWidthDescriptor(object parameters)
     {
         string? width = null;
-        
+
         // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
@@ -54,7 +54,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             // Priority: w > mw (matching Content SDK behavior)
             var wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
             if (wProp != null)
@@ -391,8 +391,8 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 continue;
             }
 
-            // Use the new overload that merges ImageParams with srcSetItem params
-            string? mediaUrl = imageField.GetMediaLink(ImageParams, srcSetItem);
+            // Use GetMediaLinkForSrcSet to preserve existing URL parameters (like ttc, tt, hash, quality, format)
+            string? mediaUrl = imageField.GetMediaLinkForSrcSet(ImageParams, srcSetItem);
             if (!string.IsNullOrEmpty(mediaUrl))
             {
                 srcSetEntries.Add($"{mediaUrl} {descriptor}");

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -418,14 +418,9 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         List<string> srcSetEntries = new();
 
-        foreach (object srcSetItem in parsedSrcSet)
+        // filter out null items directly
+        foreach (object srcSetItem in parsedSrcSet.Where(item => item != null))
         {
-            // Skip null items
-            if (srcSetItem == null)
-            {
-                continue;
-            }
-
             // Get width descriptor first to check if this entry should be included
             string? descriptor = GetWidthDescriptor(srcSetItem);
             if (descriptor == null)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -278,7 +278,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         }
 
         // Single object - wrap in array
-        return new[] { srcSetValue };
+        return [srcSetValue];
     }
 
     private TagBuilder GenerateImage(ImageField imageField, TagHelperOutput output)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -114,7 +114,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             {
                 output.Attributes.Add(ScrAttribute, field.GetMediaLink(ImageParams));
 
-                // Add srcset if configured
                 if (SrcSet != null)
                 {
                     string srcSetValue = GenerateSrcSetAttribute(field);
@@ -124,7 +123,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                     }
                 }
 
-                // Add sizes if provided
                 if (!string.IsNullOrEmpty(Sizes))
                 {
                     output.Attributes.Add(SizesAttribute, Sizes);
@@ -249,7 +247,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         return width != null ? $"{width}w" : null;
     }
 
-    private static object[]? ParseSrcSet(object? srcSetValue)
+    private static object[]? ParseJsonSrcSet(object? srcSetValue)
     {
         if (srcSetValue == null)
         {
@@ -293,7 +291,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             tagBuilder.Attributes.Add(ScrAttribute, imageField.GetMediaLink(ImageParams));
 
-            // Add srcset if configured
             if (SrcSet != null)
             {
                 string srcSetValue = GenerateSrcSetAttribute(imageField);
@@ -303,7 +300,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 }
             }
 
-            // Add sizes if provided
             if (!string.IsNullOrEmpty(Sizes))
             {
                 tagBuilder.Attributes.Add(SizesAttribute, Sizes);
@@ -387,7 +383,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
             imageNode.SetAttributeValue(ScrAttribute, imageField.GetMediaLink(ImageParams));
 
-            // Add srcset for editable content
             if (SrcSet != null)
             {
                 string srcSetValue = GenerateSrcSetAttribute(imageField);
@@ -397,7 +392,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 }
             }
 
-            // Add sizes for editable content
             if (!string.IsNullOrEmpty(Sizes))
             {
                 imageNode.SetAttributeValue(SizesAttribute, Sizes);
@@ -409,7 +403,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
     private string GenerateSrcSetAttribute(ImageField imageField)
     {
-        object[]? parsedSrcSet = ParseSrcSet(SrcSet);
+        object[]? parsedSrcSet = ParseJsonSrcSet(SrcSet);
         if (parsedSrcSet == null || parsedSrcSet.Length == 0)
         {
             return string.Empty;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -202,7 +202,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         }
         else
         {
-            // Handle anonymous objects via reflection
             PropertyInfo[] properties = parameters.GetType().GetProperties();
 
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -335,7 +335,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             return string.Empty;
         }
 
-        List<string> srcSetEntries = new();
+        List<string> srcSetEntries = [];
 
         foreach (object srcSetItem in parsedSrcSet)
         {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -247,19 +247,8 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         return width != null ? $"{width}w" : null;
     }
 
-    private static object[]? ParseJsonSrcSet(object? srcSetValue)
+    private static object[]? ParseJsonSrcSet(object srcSetValue)
     {
-        if (srcSetValue == null)
-        {
-            return null;
-        }
-
-        // If already an object array, use as-is
-        if (srcSetValue is object[] objectArray)
-        {
-            return objectArray;
-        }
-
         // If it's a JSON string, parse it
         if (srcSetValue is string jsonString)
         {
@@ -403,7 +392,24 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
     private string GenerateSrcSetAttribute(ImageField imageField)
     {
-        object[]? parsedSrcSet = ParseJsonSrcSet(SrcSet);
+        if (SrcSet == null)
+        {
+            return string.Empty;
+        }
+
+        object[]? parsedSrcSet;
+
+        // If already an object array, use as-is
+        if (SrcSet is object[] objectArray)
+        {
+            parsedSrcSet = objectArray;
+        }
+        else
+        {
+            // Parse JSON string or wrap single object
+            parsedSrcSet = ParseJsonSrcSet(SrcSet);
+        }
+
         if (parsedSrcSet == null || parsedSrcSet.Length == 0)
         {
             return string.Empty;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -433,7 +433,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 continue;
             }
 
-            // Use GetMediaLinkForSrcSet to preserve existing URL parameters (like ttc, tt, hash, quality, format)
+            // Use GetMediaLinkForSrcSet to preserve existing URL parameters (like ttc, tt, hash, quality, format) because in preview context id the images doesn't get loaded with src-set implementation
             string? mediaUrl = imageField.GetMediaLinkForSrcSet(ImageParams, srcSetItem);
             if (!string.IsNullOrEmpty(mediaUrl))
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using HtmlAgilityPack;
+﻿using System.Reflection;
+using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -61,31 +62,31 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         else
         {
             // Handle anonymous objects via reflection
-            var properties = parameters.GetType().GetProperties();
+            PropertyInfo[] properties = parameters.GetType().GetProperties();
 
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            var wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
+            PropertyInfo? wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
             if (wProp != null)
             {
                 width = wProp.GetValue(parameters)?.ToString();
             }
             else
             {
-                var mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
+                PropertyInfo? mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
                 if (mwProp != null)
                 {
                     width = mwProp.GetValue(parameters)?.ToString();
                 }
                 else
                 {
-                    var widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
+                    PropertyInfo? widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
                     if (widthProp != null)
                     {
                         width = widthProp.GetValue(parameters)?.ToString();
                     }
                     else
                     {
-                        var maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
+                        PropertyInfo? maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
                         if (maxWidthProp != null)
                         {
                             width = maxWidthProp.GetValue(parameters)?.ToString();
@@ -116,7 +117,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             try
             {
-                var parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
+                Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
                 return parsed?.Cast<object>().ToArray();
             }
             catch (System.Text.Json.JsonException)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -45,7 +45,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{kvp.Value}w";
                 }
-                
+
                 if (kvp.Key.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     kvp.Key.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -57,7 +57,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             // Handle anonymous objects via reflection
             var properties = parameters.GetType().GetProperties();
-            
+
             foreach (var prop in properties)
             {
                 if (prop.Name.Equals("mw", StringComparison.OrdinalIgnoreCase) ||
@@ -65,7 +65,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 {
                     return $"{prop.GetValue(parameters)}w";
                 }
-                
+
                 if (prop.Name.Equals("w", StringComparison.OrdinalIgnoreCase) ||
                     prop.Name.Equals("width", StringComparison.OrdinalIgnoreCase))
                 {
@@ -84,13 +84,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             return null;
         }
-        
+
         // If already an object array, use as-is
         if (srcSetValue is object[] objectArray)
         {
             return objectArray;
         }
-        
+
         // If it's a JSON string, parse it
         if (srcSetValue is string jsonString)
         {
@@ -105,7 +105,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 return null;
             }
         }
-        
+
         // Single object - wrap in array
         return new[] { srcSetValue };
     }
@@ -260,7 +260,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (!string.IsNullOrWhiteSpace(image.Src))
         {
             tagBuilder.Attributes.Add(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset if configured
             if (SrcSet != null)
             {
@@ -354,7 +354,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             }
 
             imageNode.SetAttributeValue(ScrAttribute, imageField.GetMediaLink(ImageParams));
-            
+
             // Add srcset for editable content
             if (SrcSet != null)
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -180,7 +180,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         string? width = null;
 
-        // Handle Dictionary<string, object>
         if (parameters is Dictionary<string, object> dictionary)
         {
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -211,14 +211,13 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             PropertyInfo[] properties = parameters.GetType().GetProperties();
 
-            // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
+            // Priority: w > mw > width > maxWidth
             width = TryParseParameter(parameters, "w", properties)
                 ?? TryParseParameter(parameters, "mw", properties)
                 ?? TryParseParameter(parameters, "width", properties)
                 ?? TryParseParameter(parameters, "maxWidth", properties);
         }
 
-        // Validate width is positive
         if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
         {
             return null;
@@ -229,7 +228,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
     private static object[]? ParseJsonSrcSet(object srcSetValue)
     {
-        // If it's a JSON string, parse it
         if (srcSetValue is string jsonString)
         {
             try
@@ -244,7 +242,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             }
         }
 
-        // Single object - wrap in array
         return [srcSetValue];
     }
 
@@ -379,14 +376,12 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
         object[]? parsedSrcSet;
 
-        // If already an object array, use as-is
         if (SrcSet is object[] objectArray)
         {
             parsedSrcSet = objectArray;
         }
         else
         {
-            // Parse JSON string or wrap single object
             parsedSrcSet = ParseJsonSrcSet(SrcSet);
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Fields;
 using Sitecore.AspNetCore.SDK.LayoutService.Client.Response.Model.Properties;
+using Sitecore.AspNetCore.SDK.LayoutService.Client.Serialization;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Extensions;
 using Sitecore.AspNetCore.SDK.RenderingEngine.Rendering;
 
@@ -234,8 +235,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             try
             {
                 // We need to use Dictionary<string, object>[] to ensure proper deserialization of JSON objects into dictionaries that our GetWidthDescriptor method can handle
-                Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
-                return parsed?.Cast<object>().ToArray();
+                return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString, JsonLayoutServiceSerializer.GetDefaultSerializerOptions());
             }
             catch (Exception ex)
             {

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -330,11 +330,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
 
     private string GenerateSrcSetAttribute(ImageField imageField)
     {
-        if (SrcSet == null)
-        {
-            return string.Empty;
-        }
-
         if (SrcSet is not object[] parsedSrcSet || parsedSrcSet.Length == 0)
         {
             return string.Empty;

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -183,21 +183,21 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (parameters is Dictionary<string, object> dictionary)
         {
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            if (dictionary.TryGetValue("w", out object? wValue))
+            if (dictionary.ContainsKey("w"))
             {
-                width = wValue?.ToString();
+                width = dictionary["w"]?.ToString();
             }
-            else if (dictionary.TryGetValue("mw", out object? mwValue))
+            else if (dictionary.ContainsKey("mw"))
             {
-                width = mwValue?.ToString();
+                width = dictionary["mw"]?.ToString();
             }
-            else if (dictionary.TryGetValue("width", out object? widthObj))
+            else if (dictionary.ContainsKey("width"))
             {
-                width = widthObj?.ToString();
+                width = dictionary["width"]?.ToString();
             }
-            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthObj))
+            else if (dictionary.ContainsKey("maxWidth"))
             {
-                width = maxWidthObj?.ToString();
+                width = dictionary["maxWidth"]?.ToString();
             }
         }
         else

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -257,10 +257,10 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
                 return parsed?.Cast<object>().ToArray();
             }
-            catch (System.Text.Json.JsonException)
+            catch (Exception ex)
             {
-                // If JSON parsing fails, return null to skip srcset generation
-                return null;
+                // JSON parsing failed - this is a programming error, invalid JSON was passed
+                throw new InvalidOperationException($"Failed to parse srcset JSON: {jsonString}", ex);
             }
         }
 

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -34,114 +34,6 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
     private const string SizesAttribute = "sizes";
     private readonly IEditableChromeRenderer _chromeRenderer = chromeRenderer ?? throw new ArgumentNullException(nameof(chromeRenderer));
 
-    private static string? GetWidthDescriptor(object? parameters)
-    {
-        if (parameters == null)
-        {
-            return null;
-        }
-
-        string? width = null;
-
-        // Handle Dictionary<string, object>
-        if (parameters is Dictionary<string, object> dictionary)
-        {
-            // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            if (dictionary.TryGetValue("w", out object? wValue))
-            {
-                width = wValue?.ToString();
-            }
-            else if (dictionary.TryGetValue("mw", out object? mwValue))
-            {
-                width = mwValue?.ToString();
-            }
-            else if (dictionary.TryGetValue("width", out object? widthObj))
-            {
-                width = widthObj?.ToString();
-            }
-            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthObj))
-            {
-                width = maxWidthObj?.ToString();
-            }
-        }
-        else
-        {
-            // Handle anonymous objects via reflection
-            PropertyInfo[] properties = parameters.GetType().GetProperties();
-
-            // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            PropertyInfo? wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
-            if (wProp != null)
-            {
-                width = wProp.GetValue(parameters)?.ToString();
-            }
-            else
-            {
-                PropertyInfo? mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
-                if (mwProp != null)
-                {
-                    width = mwProp.GetValue(parameters)?.ToString();
-                }
-                else
-                {
-                    PropertyInfo? widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
-                    if (widthProp != null)
-                    {
-                        width = widthProp.GetValue(parameters)?.ToString();
-                    }
-                    else
-                    {
-                        PropertyInfo? maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
-                        if (maxWidthProp != null)
-                        {
-                            width = maxWidthProp.GetValue(parameters)?.ToString();
-                        }
-                    }
-                }
-            }
-        }
-
-        // Validate width is positive
-        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
-        {
-            return null;
-        }
-
-        return width != null ? $"{width}w" : null;
-    }
-
-    private static object[]? ParseSrcSet(object? srcSetValue)
-    {
-        if (srcSetValue == null)
-        {
-            return null;
-        }
-
-        // If already an object array, use as-is
-        if (srcSetValue is object[] objectArray)
-        {
-            return objectArray;
-        }
-
-        // If it's a JSON string, parse it
-        if (srcSetValue is string jsonString)
-        {
-            try
-            {
-                Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
-                return parsed?.Cast<object>().ToArray();
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                // If JSON parsing fails, return null to skip srcset generation
-                return null;
-            }
-        }
-
-        // Single object - wrap in array
-        return new[] { srcSetValue };
-    }
-
     /// <summary>
     /// Gets or sets the model value.
     /// </summary>
@@ -279,6 +171,114 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 }
             }
         }
+    }
+
+    private static string? GetWidthDescriptor(object? parameters)
+    {
+        if (parameters == null)
+        {
+            return null;
+        }
+
+        string? width = null;
+
+        // Handle Dictionary<string, object>
+        if (parameters is Dictionary<string, object> dictionary)
+        {
+            // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
+            if (dictionary.TryGetValue("w", out object? wValue))
+            {
+                width = wValue?.ToString();
+            }
+            else if (dictionary.TryGetValue("mw", out object? mwValue))
+            {
+                width = mwValue?.ToString();
+            }
+            else if (dictionary.TryGetValue("width", out object? widthObj))
+            {
+                width = widthObj?.ToString();
+            }
+            else if (dictionary.TryGetValue("maxWidth", out object? maxWidthObj))
+            {
+                width = maxWidthObj?.ToString();
+            }
+        }
+        else
+        {
+            // Handle anonymous objects via reflection
+            PropertyInfo[] properties = parameters.GetType().GetProperties();
+
+            // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
+            PropertyInfo? wProp = properties.FirstOrDefault(p => p.Name.Equals("w", StringComparison.OrdinalIgnoreCase));
+            if (wProp != null)
+            {
+                width = wProp.GetValue(parameters)?.ToString();
+            }
+            else
+            {
+                PropertyInfo? mwProp = properties.FirstOrDefault(p => p.Name.Equals("mw", StringComparison.OrdinalIgnoreCase));
+                if (mwProp != null)
+                {
+                    width = mwProp.GetValue(parameters)?.ToString();
+                }
+                else
+                {
+                    PropertyInfo? widthProp = properties.FirstOrDefault(p => p.Name.Equals("width", StringComparison.OrdinalIgnoreCase));
+                    if (widthProp != null)
+                    {
+                        width = widthProp.GetValue(parameters)?.ToString();
+                    }
+                    else
+                    {
+                        PropertyInfo? maxWidthProp = properties.FirstOrDefault(p => p.Name.Equals("maxWidth", StringComparison.OrdinalIgnoreCase));
+                        if (maxWidthProp != null)
+                        {
+                            width = maxWidthProp.GetValue(parameters)?.ToString();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Validate width is positive
+        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
+        {
+            return null;
+        }
+
+        return width != null ? $"{width}w" : null;
+    }
+
+    private static object[]? ParseSrcSet(object? srcSetValue)
+    {
+        if (srcSetValue == null)
+        {
+            return null;
+        }
+
+        // If already an object array, use as-is
+        if (srcSetValue is object[] objectArray)
+        {
+            return objectArray;
+        }
+
+        // If it's a JSON string, parse it
+        if (srcSetValue is string jsonString)
+        {
+            try
+            {
+                Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
+                return parsed?.Cast<object>().ToArray();
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // If JSON parsing fails, return null to skip srcset generation
+                return null;
+            }
+        }
+
+        // Single object - wrap in array
+        return new[] { srcSetValue };
     }
 
     private TagBuilder GenerateImage(ImageField imageField, TagHelperOutput output)

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -254,6 +254,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         {
             try
             {
+                // We need to use Dictionary<string, object>[] to ensure proper deserialization of JSON objects into dictionaries that our GetWidthDescriptor method can handle
                 Dictionary<string, object>[]? parsed = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString);
                 return parsed?.Cast<object>().ToArray();
             }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -191,21 +191,21 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
         if (parameters is Dictionary<string, object> dictionary)
         {
             // Priority: w > mw > width > maxWidth (matching Content SDK behavior + legacy support)
-            if (dictionary.ContainsKey("w"))
+            if (dictionary.TryGetValue("w", out var wValue))
             {
-                width = dictionary["w"]?.ToString();
+                width = wValue.ToString();
             }
-            else if (dictionary.ContainsKey("mw"))
+            else if (dictionary.TryGetValue("mw", out var mwValue))
             {
-                width = dictionary["mw"]?.ToString();
+                width = mwValue.ToString();
             }
-            else if (dictionary.ContainsKey("width"))
+            else if (dictionary.TryGetValue("width", out var widthValue))
             {
-                width = dictionary["width"]?.ToString();
+                width = widthValue.ToString();
             }
-            else if (dictionary.ContainsKey("maxWidth"))
+            else if (dictionary.TryGetValue("maxWidth", out var maxWidthValue))
             {
-                width = dictionary["maxWidth"]?.ToString();
+                width = maxWidthValue.ToString();
             }
         }
         else
@@ -219,7 +219,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
                 ?? TryParseParameter(parameters, "maxWidth", properties);
         }
 
-        if (width != null && int.TryParse(width, out int widthValue) && widthValue <= 0)
+        if (width != null && int.TryParse(width, out int widthValueInt) && widthValueInt <= 0)
         {
             return null;
         }

--- a/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.RenderingEngine/TagHelpers/Fields/ImageTagHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Text.Json;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -233,7 +234,7 @@ public class ImageTagHelper(IEditableChromeRenderer chromeRenderer) : TagHelper
             try
             {
                 // We need to use Dictionary<string, object>[] to ensure proper deserialization of JSON objects into dictionaries that our GetWidthDescriptor method can handle
-                return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString, JsonLayoutServiceSerializer.GetDefaultSerializerOptions());
+                return JsonSerializer.Deserialize<Dictionary<string, object>[]>(jsonString, JsonLayoutServiceSerializer.GetDefaultSerializerOptions());
             }
             catch (Exception ex)
             {

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
@@ -9,4 +9,7 @@ public class ComponentWithImages
     public ImageField? SecondImage { get; set; }
 
     public TextField? Heading { get; set; }
+
+    public ImageField? ThirdImage { get; set; }
+
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
@@ -13,5 +13,4 @@ public class ComponentWithImages
     public ImageField? ThirdImage { get; set; }
 
     public ImageField? FourthImage { get; set; }
-
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/ComponentModels/ComponentWithImages.cs
@@ -12,4 +12,6 @@ public class ComponentWithImages
 
     public ImageField? ThirdImage { get; set; }
 
+    public ImageField? FourthImage { get; set; }
+
 }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
@@ -145,8 +145,8 @@ public class ImageFieldTagHelperFixture : IDisposable
         // Assert
         // check that image url contains mw and mh parameters
         secondImage.Should().NotBeNull();
-        secondImage.Attributes.Should().Contain(a => a.Name == "src");
-        secondImage.Attributes["src"].Value.Should().Contain("mw=100&amp;mh=50");
+        secondImage?.Attributes.Should().Contain(a => a.Name == "src");
+        secondImage?.Attributes["src"].Value.Should().Contain("mw=100&amp;mh=50");
     }
 
     [Fact]
@@ -196,25 +196,21 @@ public class ImageFieldTagHelperFixture : IDisposable
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-images"));
 
         // Assert
-        // Third image (index 2)
+        // Third image for <sc-img /> (index 2)
         HtmlNode? thirdImg = sectionNode.Descendants("img").ElementAt(2);
         thirdImg.Should().NotBeNull();
         thirdImg.Attributes.Should().Contain(a => a.Name == "srcset");
-        string thirdSrcSet = thirdImg.Attributes["srcset"].Value;
-        thirdSrcSet.Should().Contain("site/third.png?mw=400 400w");
-        thirdSrcSet.Should().Contain("site/third.png?mw=200 200w");
+        thirdImg.Attributes.Should().Contain(a => a.Name == "sizes");
 
-        // Fourth image (index 3)
+        // Fourth image for <img /> (index 3)
         HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
         fourthImg.Should().NotBeNull();
         fourthImg.Attributes.Should().Contain(a => a.Name == "srcset");
-        string fourthSrcSet = fourthImg.Attributes["srcset"].Value;
-        fourthSrcSet.Should().Contain("site/fourth.png?mw=800 800w");
-        fourthSrcSet.Should().Contain("site/fourth.png?mw=400 400w");
+        fourthImg.Attributes.Should().Contain(a => a.Name == "sizes");
     }
 
     [Fact]
-    public async Task ImgTagHelper_SrcSetAttributeContainsCorrectUrls()
+    public async Task ImgTagHelper_SrcSetAttributeContainsCorrectUrlsAndSizes()
     {
         // Arrange
         _mockClientHandler.Responses.Push(new HttpResponseMessage
@@ -232,19 +228,19 @@ public class ImageFieldTagHelperFixture : IDisposable
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-images"));
 
         // Assert
-        // Third image (index 2)
+        // Third image for <sc-img /> (index 2)
         HtmlNode? thirdImg = sectionNode.Descendants("img").ElementAt(2);
         thirdImg.Should().NotBeNull();
-        string thirdSrcSet = thirdImg.Attributes["srcset"].Value;
-        thirdSrcSet.Should().Contain("site/third.png?mw=400 400w");
-        thirdSrcSet.Should().Contain("site/third.png?mw=200 200w");
+        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=400 400w");
+        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=200 200w");
+        thirdImg.Attributes["sizes"].Value.Should().Be("(min-width: 400px) 400px, 200px");
 
-        // Fourth image (index 3)
+        // Fourth image for <img /> (index 3)
         HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
         fourthImg.Should().NotBeNull();
-        string fourthSrcSet = fourthImg.Attributes["srcset"].Value;
-        fourthSrcSet.Should().Contain("site/fourth.png?mw=800 800w");
-        fourthSrcSet.Should().Contain("site/fourth.png?mw=400 400w");
+        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=800 800w");
+        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=400 400w");
+        fourthImg.Attributes["sizes"].Value.Should().Be("(min-width: 800px) 800px, 400px");
     }
 
     public void Dispose()

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
@@ -201,12 +201,18 @@ public class ImageFieldTagHelperFixture : IDisposable
         thirdImg.Should().NotBeNull();
         thirdImg.Attributes.Should().Contain(a => a.Name == "srcset");
         thirdImg.Attributes.Should().Contain(a => a.Name == "sizes");
+        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=400 400w");
+        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=200 200w");
+        thirdImg.Attributes["sizes"].Value.Should().Be("(min-width: 400px) 400px, 200px");
 
         // Fourth image for <img /> (index 3)
         HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
         fourthImg.Should().NotBeNull();
         fourthImg.Attributes.Should().Contain(a => a.Name == "srcset");
         fourthImg.Attributes.Should().Contain(a => a.Name == "sizes");
+        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=800 800w");
+        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=400 400w");
+        fourthImg.Attributes["sizes"].Value.Should().Be("(min-width: 800px) 800px, 400px");
     }
 
     [Fact]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
@@ -95,7 +95,7 @@ public class ImageFieldTagHelperFixture : IDisposable
 
         // Assert
         // check that there is proper number of 'img' tags generated.
-        sectionNode.ChildNodes.Count(n => n.Name.Equals("img", StringComparison.OrdinalIgnoreCase)).Should().Be(3);
+        sectionNode.ChildNodes.Count(n => n.Name.Equals("img", StringComparison.OrdinalIgnoreCase)).Should().Be(4);
     }
 
     [Fact]
@@ -191,16 +191,26 @@ public class ImageFieldTagHelperFixture : IDisposable
 
         // Act
         string response = await client.GetStringAsync(new Uri("/", UriKind.Relative));
-        HtmlDocument doc = new();
+        HtmlDocument doc = new HtmlDocument();
         doc.LoadHtml(response);
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-images"));
-        HtmlNode? imgNode = sectionNode.Descendants("img").ElementAt(2);
 
         // Assert
-        imgNode.Should().NotBeNull();
-        imgNode.Attributes.Should().Contain(a => a.Name == "srcset");
-        imgNode.Attributes["srcset"].Value.Should().Contain("400w");
-        imgNode.Attributes["srcset"].Value.Should().Contain("200w");
+        // Third image (index 2)
+        HtmlNode? thirdImg = sectionNode.Descendants("img").ElementAt(2);
+        thirdImg.Should().NotBeNull();
+        thirdImg.Attributes.Should().Contain(a => a.Name == "srcset");
+        string thirdSrcSet = thirdImg.Attributes["srcset"].Value;
+        thirdSrcSet.Should().Contain("site/third.png?mw=400 400w");
+        thirdSrcSet.Should().Contain("site/third.png?mw=200 200w");
+
+        // Fourth image (index 3)
+        HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
+        fourthImg.Should().NotBeNull();
+        fourthImg.Attributes.Should().Contain(a => a.Name == "srcset");
+        string fourthSrcSet = fourthImg.Attributes["srcset"].Value;
+        fourthSrcSet.Should().Contain("site/fourth.png?mw=800 800w");
+        fourthSrcSet.Should().Contain("site/fourth.png?mw=400 400w");
     }
 
     [Fact]
@@ -217,16 +227,24 @@ public class ImageFieldTagHelperFixture : IDisposable
 
         // Act
         string response = await client.GetStringAsync(new Uri("/", UriKind.Relative));
-        HtmlDocument doc = new();
+        HtmlDocument doc = new HtmlDocument();
         doc.LoadHtml(response);
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-images"));
-        HtmlNode? imgNode = sectionNode.Descendants("img").ElementAt(2);
 
         // Assert
-        imgNode.Should().NotBeNull();
-        var srcSet = imgNode.Attributes["srcset"].Value;
-        srcSet.Should().Contain("mw=400 400w");
-        srcSet.Should().Contain("mw=200 200w");
+        // Third image (index 2)
+        HtmlNode? thirdImg = sectionNode.Descendants("img").ElementAt(2);
+        thirdImg.Should().NotBeNull();
+        string thirdSrcSet = thirdImg.Attributes["srcset"].Value;
+        thirdSrcSet.Should().Contain("site/third.png?mw=400 400w");
+        thirdSrcSet.Should().Contain("site/third.png?mw=200 200w");
+
+        // Fourth image (index 3)
+        HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
+        fourthImg.Should().NotBeNull();
+        string fourthSrcSet = fourthImg.Attributes["srcset"].Value;
+        fourthSrcSet.Should().Contain("site/fourth.png?mw=800 800w");
+        fourthSrcSet.Should().Contain("site/fourth.png?mw=400 400w");
     }
 
     public void Dispose()

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/ImageFieldTagHelperFixture.cs
@@ -178,7 +178,7 @@ public class ImageFieldTagHelperFixture : IDisposable
     }
 
     [Fact]
-    public async Task ImgTagHelper_GeneratesProperSrcSetAttribute()
+    public async Task ImgTagHelper_GeneratesProperSrcSetAttributeWithCorrectUrlsAndSizes()
     {
         // Arrange
         _mockClientHandler.Responses.Push(new HttpResponseMessage
@@ -210,40 +210,6 @@ public class ImageFieldTagHelperFixture : IDisposable
         fourthImg.Should().NotBeNull();
         fourthImg.Attributes.Should().Contain(a => a.Name == "srcset");
         fourthImg.Attributes.Should().Contain(a => a.Name == "sizes");
-        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=800 800w");
-        fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=400 400w");
-        fourthImg.Attributes["sizes"].Value.Should().Be("(min-width: 800px) 800px, 400px");
-    }
-
-    [Fact]
-    public async Task ImgTagHelper_SrcSetAttributeContainsCorrectUrlsAndSizes()
-    {
-        // Arrange
-        _mockClientHandler.Responses.Push(new HttpResponseMessage
-        {
-            StatusCode = HttpStatusCode.OK,
-            Content = new StringContent(Serializer.Serialize(CannedResponses.PageWithPreview))
-        });
-
-        HttpClient client = _server.CreateClient();
-
-        // Act
-        string response = await client.GetStringAsync(new Uri("/", UriKind.Relative));
-        HtmlDocument doc = new HtmlDocument();
-        doc.LoadHtml(response);
-        HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-images"));
-
-        // Assert
-        // Third image for <sc-img /> (index 2)
-        HtmlNode? thirdImg = sectionNode.Descendants("img").ElementAt(2);
-        thirdImg.Should().NotBeNull();
-        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=400 400w");
-        thirdImg.Attributes["srcset"].Value.Should().Contain("site/third.png?mw=200 200w");
-        thirdImg.Attributes["sizes"].Value.Should().Be("(min-width: 400px) 400px, 200px");
-
-        // Fourth image for <img /> (index 3)
-        HtmlNode? fourthImg = sectionNode.Descendants("img").ElementAt(3);
-        fourthImg.Should().NotBeNull();
         fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=800 800w");
         fourthImg.Attributes["srcset"].Value.Should().Contain("site/fourth.png?mw=400 400w");
         fourthImg.Attributes["sizes"].Value.Should().Be("(min-width: 800px) 800px, 400px");

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComponentWithImages.cshtml
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComponentWithImages.cshtml
@@ -5,4 +5,5 @@
     <div asp-for="Heading"></div>
     <img asp-for="SecondImage" height="50" width="94" image-params="new { mw = 100, mh = 50 }" data-sample="other-attributes-pass-through" />
     <sc-img asp-for="ThirdImage" src-set='new object[] { new { mw = 400 }, new { mw = 200 } }' sizes="(min-width: 400px) 400px, 200px" />    
+    <img asp-for="FourthImage" src-set='new object[] { new { mw = 800 }, new { mw = 400 } }' sizes="(min-width: 800px) 800px, 400px" />
 </section>

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComponentWithImages.cshtml
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Views/Shared/Components/SitecoreComponent/ComponentWithImages.cshtml
@@ -4,4 +4,5 @@
     <sc-img asp-for="FirstImage" />
     <div asp-for="Heading"></div>
     <img asp-for="SecondImage" height="50" width="94" image-params="new { mw = 100, mh = 50 }" data-sample="other-attributes-pass-through" />
+    <sc-img asp-for="ThirdImage" src-set='new object[] { new { mw = 400 }, new { mw = 200 } }' sizes="(min-width: 400px) 400px, 200px" />    
 </section>

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -920,6 +920,275 @@ public class ImageTagHelperFixture
         tagHelperOutput.Attributes.Should().NotContain(a => a.Name == "srcset");
     }
 
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithImageParamsConflict_SrcSetParametersWin(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.ImageParams = new { w = 1000, quality = 50, format = "jpg" };
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("w=320");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("format=jpg"); // Inherited from ImageParams
+        srcSetValue.Should().NotContain("w=1000");
+        srcSetValue.Should().NotContain("quality=50");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithWidthParameterPriority_UsesCorrectPrecedence(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange - Test priority: w > mw > width > maxWidth
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 100, mw = 200, width = 300, maxWidth = 400 }, // Should use w=100
+            new { mw = 200, width = 300, maxWidth = 400 }, // Should use mw=200
+            new { width = 300, maxWidth = 400 }, // Should use width=300
+            new { maxWidth = 400 } // Should use maxWidth=400
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("100w");
+        srcSetValue.Should().Contain("200w");
+        srcSetValue.Should().Contain("300w");
+        srcSetValue.Should().Contain("400w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithZeroOrNegativeWidths_SkipsInvalidEntries(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 0, quality = 75 },    // Should skip
+            new { w = -100, quality = 80 }, // Should skip
+            new { w = 320, quality = 75 },  // Should include
+            new { quality = 90 } // Should skip - no width
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().NotContain(" 0w");
+        srcSetValue.Should().NotContain(" -100w");
+
+        // Should only have one entry
+        string[] entries = srcSetValue.Split(", ");
+        entries.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithExistingUrlParameters_PreservesAndMergesParameters(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        Image imageWithParams = new Image
+        {
+            Src = "https://edge.sitecorecloud.io/media/image.jpg?h=2001&iar=0&hash=abc123&w=3000",
+            Alt = "Test Image"
+        };
+
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(imageWithParams));
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+
+        // Should preserve existing parameters and merge with new ones
+        srcSetValue.Should().Contain("h=2001");
+        srcSetValue.Should().Contain("iar=0");
+        srcSetValue.Should().Contain("hash=abc123");
+        srcSetValue.Should().Contain("quality=75");
+
+        // New w parameter should override existing w=3000
+        srcSetValue.Should().Contain("w=320");
+        srcSetValue.Should().NotContain("w=3000");
+        srcSetValue.Should().Contain("320w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithMediaUrlTransformation_TransformsCorrectly(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        Image imageWithMediaUrl = new Image
+        {
+            Src = "/~/media/images/test.jpg",
+            Alt = "Test Image"
+        };
+
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(imageWithMediaUrl));
+        sut.SrcSet = new object[] { new { w = 320, quality = 75 } };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+
+        // Should transform /~/media/ to /~/jssmedia/
+        srcSetValue.Should().Contain("/~/jssmedia/images/test.jpg");
+        srcSetValue.Should().NotContain("/~/media/images/test.jpg");
+        srcSetValue.Should().Contain("320w");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithNullAndEmptyEntries_HandlesGracefully(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object?[]
+        {
+            new { w = 320, quality = 75 },
+            null, // Should skip
+            new { w = 480, quality = 80 },
+            new { } // Should skip - no width parameter
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("480w");
+
+        // Should only have two entries
+        string[] entries = srcSetValue.Split(", ");
+        entries.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithComplexParameters_HandlesAllParameters(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new { w = 320, quality = 75, format = "webp", dpr = 2, fit = "crop" }
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("format=webp");
+        srcSetValue.Should().Contain("dpr=2");
+        srcSetValue.Should().Contain("fit=crop");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithDictionaryParameters_GeneratesSrcSetAttribute(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[]
+        {
+            new Dictionary<string, object> { { "w", 320 }, { "quality", 75 } },
+            new Dictionary<string, object> { { "mw", 480 }, { "quality", 80 } }
+        };
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
+        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
+        srcSetValue.Should().Contain("320w");
+        srcSetValue.Should().Contain("480w");
+        srcSetValue.Should().Contain("quality=75");
+        srcSetValue.Should().Contain("quality=80");
+    }
+
+    [Theory]
+    [AutoNSubstituteData]
+    public void Process_SrcSetWithSizesAttribute_AddsBothAttributes(
+        ImageTagHelper sut,
+        TagHelperContext tagHelperContext,
+        TagHelperOutput tagHelperOutput)
+    {
+        // Arrange
+        tagHelperOutput.TagName = "img";
+        sut.For = GetModelExpression(new ImageField(_image));
+        sut.SrcSet = new object[] { new { w = 320 }, new { w = 480 } };
+        sut.Sizes = "(min-width: 768px) 480px, 320px";
+
+        // Act
+        sut.Process(tagHelperContext, tagHelperOutput);
+
+        // Assert
+        tagHelperOutput.Attributes.Should().Contain(a => a.Name == "srcset");
+        tagHelperOutput.Attributes.Should().Contain(a => a.Name == "sizes");
+
+        string sizesValue = tagHelperOutput.Attributes["sizes"].Value.ToString()!;
+        sizesValue.Should().Be("(min-width: 768px) 480px, 320px");
+    }
+
     private static ModelExpression GetModelExpression(Field model)
     {
         DefaultModelMetadata? modelMetadata = Substitute.For<DefaultModelMetadata>(

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -902,7 +902,7 @@ public class ImageTagHelperFixture
 
     [Theory]
     [AutoNSubstituteData]
-    public void Process_SrcSetWithInvalidJsonString_FallsBackGracefully(
+    public void Process_SrcSetWithInvalidJsonString_ThrowsInvalidOperationException(
         ImageTagHelper sut,
         TagHelperContext tagHelperContext,
         TagHelperOutput tagHelperOutput)
@@ -912,12 +912,12 @@ public class ImageTagHelperFixture
         sut.For = GetModelExpression(new ImageField(_image));
         sut.SrcSet = "invalid json string";
 
-        // Act
-        sut.Process(tagHelperContext, tagHelperOutput);
-
-        // Assert
-        // Should not throw and should not add srcset attribute
-        tagHelperOutput.Attributes.Should().NotContain(a => a.Name == "srcset");
+        // Act & Assert
+        // Should throw InvalidOperationException due to invalid JSON
+        Action act = () => sut.Process(tagHelperContext, tagHelperOutput);
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("Failed to parse srcset JSON: invalid json string*")
+           .WithInnerException<System.Text.Json.JsonException>();
     }
 
     [Theory]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -798,7 +798,7 @@ public class ImageTagHelperFixture
         {
             EditableMarkup = "<img src=\"/sitecore/shell/-/jssmedia/img/sc_logo.png\" alt=\"Sitecore Logo\" />"
         };
-        
+
         tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.ImageHtmlTag;
         sut.For = GetModelExpression(imageField);
         sut.SrcSet = new object[] { new { mw = 600 }, new { mw = 300 } };

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -863,29 +863,6 @@ public class ImageTagHelperFixture
 
     [Theory]
     [AutoNSubstituteData]
-    public void Process_SrcSetWithJsonString_GeneratesSrcSetAttribute(
-        ImageTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
-    {
-        // Arrange
-        tagHelperOutput.TagName = "img";
-        sut.For = GetModelExpression(new ImageField(_image));
-        sut.SrcSet = "[{\"mw\": 500}, {\"mw\": 250}]";
-
-        // Act
-        sut.Process(tagHelperContext, tagHelperOutput);
-
-        // Assert
-        tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
-        string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-
-        // Full string comparison
-        srcSetValue.Should().Be("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&hash=F313AD90AE547CAB09277E42509E289B&mw=500 500w, http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&hash=F313AD90AE547CAB09277E42509E289B&mw=250 250w");
-    }
-
-    [Theory]
-    [AutoNSubstituteData]
     public void Process_SrcSetWithMixedParameterTypes_GeneratesSrcSetAttribute(
         ImageTagHelper sut,
         TagHelperContext tagHelperContext,
@@ -913,25 +890,6 @@ public class ImageTagHelperFixture
 
         // Full string comparison
         srcsetValue.Should().Be("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=800 800w, http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;mw=400 400w");
-    }
-
-    [Theory]
-    [AutoNSubstituteData]
-    public void Process_SrcSetWithInvalidJsonString_ThrowsInvalidOperationException(
-        ImageTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
-    {
-        // Arrange
-        tagHelperOutput.TagName = "img";
-        sut.For = GetModelExpression(new ImageField(_image));
-        sut.SrcSet = "invalid json string";
-
-        // Act & Assert
-        Action act = () => sut.Process(tagHelperContext, tagHelperOutput);
-        act.Should().Throw<InvalidOperationException>()
-           .WithMessage("Failed to parse srcset JSON: invalid json string*")
-           .WithInnerException<System.Text.Json.JsonException>();
     }
 
     [Theory]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -757,7 +757,7 @@ public class ImageTagHelperFixture
         // Assert
         string content = tagHelperOutput.Content.GetContent();
 
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue("srcset attribute should be present in the HTML");
 
         string srcsetValue = srcsetMatch.Groups[1].Value;
@@ -766,7 +766,7 @@ public class ImageTagHelperFixture
         srcsetValue.Should().Contain("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=400 400w");
         srcsetValue.Should().Contain("http://styleguide/-/jssmedia/styleguide/data/media/img/sc_logo.png?iar=0&amp;hash=F313AD90AE547CAB09277E42509E289B&amp;w=200 200w");
 
-        var entries = srcsetValue.Split(", ");
+        string[] entries = srcsetValue.Split(", ");
         entries.Should().HaveCount(2);
     }
 
@@ -848,11 +848,11 @@ public class ImageTagHelperFixture
         string content = tagHelperOutput.Content.GetContent();
 
         // Extract srcset and sizes using regex for full string comparison
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue();
         string srcsetValue = srcsetMatch.Groups[1].Value;
 
-        var sizesMatch = System.Text.RegularExpressions.Regex.Match(content, "sizes=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match sizesMatch = System.Text.RegularExpressions.Regex.Match(content, "sizes=\"([^\"]*)\"");
         sizesMatch.Success.Should().BeTrue();
         string sizesValue = sizesMatch.Groups[1].Value;
 
@@ -884,7 +884,7 @@ public class ImageTagHelperFixture
         string content = tagHelperOutput.Content.GetContent();
 
         // Extract srcset using regex for full string comparison
-        var srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
+        System.Text.RegularExpressions.Match srcsetMatch = System.Text.RegularExpressions.Regex.Match(content, "srcset=\"([^\"]*)\"");
         srcsetMatch.Success.Should().BeTrue();
         string srcsetValue = srcsetMatch.Groups[1].Value;
 

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/ImageTagHelperFixture.cs
@@ -780,14 +780,15 @@ public class ImageTagHelperFixture
         // Assert
         tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
         string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-        
+
         // Should contain "1000w" (from w parameter taking priority over h)
         srcSetValue.Should().Contain("1000w");
+
         // Should contain "250w" (from mw parameter)
         srcSetValue.Should().Contain("250w");
-        
+
         // Verify it contains the expected format: "url 1000w, url 250w"
-        var entries = srcSetValue.Split(", ");
+        string[] entries = srcSetValue.Split(", ");
         entries.Should().HaveCount(2);
         entries[0].Should().EndWith("1000w");
         entries[1].Should().EndWith("250w");
@@ -811,11 +812,12 @@ public class ImageTagHelperFixture
         // Assert
         tagHelperOutput.Attributes.Should().ContainSingle(a => a.Name == "srcset");
         string srcSetValue = tagHelperOutput.Attributes["srcset"].Value.ToString()!;
-        
+
         // Should only contain the entry with mw parameter
         srcSetValue.Should().Contain("250w");
+
         // Should not contain entries without width parameters
-        var entries = srcSetValue.Split(", ");
+        string[] entries = srcSetValue.Split(", ");
         entries.Should().HaveCount(1);
     }
 
@@ -883,9 +885,9 @@ public class ImageTagHelperFixture
         sut.For = GetModelExpression(new ImageField(_image));
         sut.SrcSet = new object[]
         {
+            // Only w and mw are supported by Content SDK for srcSet
             new { w = 800 },  // Anonymous object with 'w'
             new { mw = 400 }, // Anonymous object with 'mw'
-            // Only w and mw are supported by Content SDK for srcSet
         };
 
         // Act

--- a/tests/data/Sitecore.AspNetCore.SDK.TestData/CannedResponses.cs
+++ b/tests/data/Sitecore.AspNetCore.SDK.TestData/CannedResponses.cs
@@ -2988,6 +2988,8 @@ public static class CannedResponses
                                 ["FirstImage"] = new ImageField(new Image { Alt = "sample", Src = "sample.png" }),
                                 ["SecondImage"] = new ImageField(new Image
                                     { Alt = "second", Src = "site/second.png" }),
+                                ["ThirdImage"] = new ImageField(new Image
+                                    { Alt = "third", Src = "site/third.png" }),
                                 ["Heading"] = new TextField(TestConstants.TestFieldValue),
                             }
                         },
@@ -3894,6 +3896,8 @@ public static class CannedResponses
                                 ["FirstImage"] = new ImageField(new Image { Alt = "sample", Src = "sample.png" }),
                                 ["SecondImage"] = new ImageField(new Image
                                     { Alt = "second", Src = "site/second.png" }),
+                                ["ThirdImage"] = new ImageField(new Image
+                                    { Alt = "third", Src = "site/third.png" }),
                                 ["Heading"] = new TextField(TestConstants.TestFieldValue),
                             }
                         },

--- a/tests/data/Sitecore.AspNetCore.SDK.TestData/CannedResponses.cs
+++ b/tests/data/Sitecore.AspNetCore.SDK.TestData/CannedResponses.cs
@@ -2990,6 +2990,8 @@ public static class CannedResponses
                                     { Alt = "second", Src = "site/second.png" }),
                                 ["ThirdImage"] = new ImageField(new Image
                                     { Alt = "third", Src = "site/third.png" }),
+                                ["FourthImage"] = new ImageField(new Image
+                                    { Alt = "fourth", Src = "site/fourth.png" }),
                                 ["Heading"] = new TextField(TestConstants.TestFieldValue),
                             }
                         },
@@ -3898,6 +3900,8 @@ public static class CannedResponses
                                     { Alt = "second", Src = "site/second.png" }),
                                 ["ThirdImage"] = new ImageField(new Image
                                     { Alt = "third", Src = "site/third.png" }),
+                                ["FourthImage"] = new ImageField(new Image
+                                    { Alt = "fourth", Src = "site/fourth.png" }),
                                 ["Heading"] = new TextField(TestConstants.TestFieldValue),
                             }
                         },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR implements responsive image support for the `ImageTagHelper` by adding `srcset` and `sizes` attribute functionality, enabling developers to output responsive images using Sitecore's built-in media resizing capabilities. 

### Key Changes:

1. **Added `SrcSet` and `Sizes` Properties**: Extended the `ImageTagHelper` with new properties to support responsive image configuration for both `<sc-img>` and `<img>` tags.

2. **Multiple Input Format Support**: The `SrcSet` property accepts two different input formats for maximum flexibility:
   - **Anonymous objects**: `new object[] { new { w = 800 }, new { mw = 400 } }`
   - **Dictionary arrays**: `new Dictionary<string, object> { {"w", 800} }`

3. **Content SDK Parameter Priority**: Implements the same parameter precedence as Content SDK:
   - `w` (width) takes priority over `mw` (max width) for srcset descriptors
   - Extended support for legacy parameters: `w` > `mw` > `width` > `maxWidth`
   - Only entries with valid width parameters are included in srcset
   - Matches Content SDK's `getSrcSet` function behavior exactly

4. **Enhanced Parameter Merging with Preservation**: 
   - Base `imageParams` are merged with individual `srcSet` parameters
   - `srcSet` parameters override `imageParams` for each srcset entry
   - **Critical Fix**: Added `GetSitecoreMediaUriWithPreservation` method to preserve existing query parameters
   - Preserves essential Sitecore parameters (rev, db, la, vs, ts, hash, ttc, tt, etc.)
   - Follows Content SDK's `{ ...imageParams, ...params }` merge pattern

5. **Dual URL Processing Methods**: 
   - **Legacy `GetSitecoreMediaUri`**: Maintains existing behavior (strips query parameters)
   - **New `GetSitecoreMediaUriWithPreservation`**: Preserves critical parameters for responsive images
   - **`GetMediaLinkForSrcSet`**: Specialized method for srcSet URL generation with parameter preservation
   - Ensures backward compatibility while fixing responsive image display issues

### Content SDK Compatibility:

The implementation now produces identical output to the Content SDK's `Image` component:

**Content SDK (React):**
```jsx
<Image 
  field={imageField} 
  imageParams={{quality: 80}} 
  srcSet={[{w: 800}, {mw: 400}]} 
  sizes="(min-width: 768px) 800px, 400px" 
/>
```

**ASP.NET Core SDK (Razor):**
```html
<sc-img asp-for="@Model.ImageField" 
        image-params='new { quality = 80 }'
        src-set='new object[] { new { w = 800 }, new { mw = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```


### Technical Implementation Details:

1. **Parameter Preservation Architecture**:
   - `MergeParameters()`: Merges base and override parameters using reflection and dictionary handling
   - `GetSitecoreMediaUriWithPreservation()`: Preserves existing URL parameters while adding new ones
   - `ConvertToStringDictionary()`: Converts objects to string dictionaries for URL building
   - `GetMediaLinkForSrcSet()`: Specialized extension method for responsive image URL generation

2. **JsonElement Handling**: Enhanced support for JSON deserialization scenarios to handle `JsonElement` types properly

3. **Helper Methods**: Added `AddResponsiveImageAttributes()` overloads to eliminate code duplication across `Process()`, `GenerateImage()`, and editable markup methods

### Usage Examples:

```html
<!-- Basic responsive image -->
<sc-img asp-for="@Model.HeroImage" 
        src-set='new object[] { new { w = 1200 }, new { w = 800 }, new { w = 400 } }'
        sizes="(min-width: 1200px) 1200px, (min-width: 800px) 800px, 400px" />

<!-- With base parameters (preserves existing URL params) -->
<img asp-for="@Model.ProductImage" 
     image-params='new { quality = 80, format = "webp" }'
     src-set='new object[] { new { w = 800, h = 600 }, new { mw = 400, mh = 300 } }'
     sizes="(min-width: 768px) 800px, 400px" />

<!-- Legacy parameter support -->
<sc-img asp-for="@Model.LegacyImage" 
        src-set='new object[] { new { width = 800 }, new { maxWidth = 400 } }'
        sizes="(min-width: 768px) 800px, 400px" />
```

This implementation ensures feature parity with the Content SDK while maintaining the familiar ASP.NET Core TagHelper syntax, full backward compatibility, and proper parameter preservation for functional image display.

## Testing

- [x] The Unit & Integration tests are passing.
- [x] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [x] I agree to follow this project's Code of Conduct.

Fix #16
