### PR TITLE
Option 3 - fixed - Update date formatting tests to handle culture specific formats

### DIFF
--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/Binding/ViewFieldsBindingFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using FluentAssertions;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.TestHost;
@@ -75,7 +76,8 @@ public class ViewFieldsBindingFixture : IDisposable
         sectionNode.ChildNodes.First(n => n.Name.Equals("p", StringComparison.OrdinalIgnoreCase)).InnerText
             .Should().BeEmpty();
 
-        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019");
+        DateTime expectedDate = DateTime.Parse("12.12.19", CultureInfo.InvariantCulture);
+        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain(expectedDate.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
 
         sectionNode.ChildNodes.First(n => n.Name.Equals("span", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.TestMultilineFieldValue.Replace(Environment.NewLine, "<br>", StringComparison.OrdinalIgnoreCase));

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/AllFieldTagHelpersFixture.cs
@@ -82,7 +82,7 @@ public class AllFieldTagHelpersFixture : IDisposable
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div5", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.AllFieldsImageValue);
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div6", StringComparison.OrdinalIgnoreCase)).InnerHtml
-            .Should().Be(TestConstants.DateFieldValue);
+            .Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div7", StringComparison.OrdinalIgnoreCase)).InnerHtml
             .Should().Be(TestConstants.MediaLibraryItemImageFieldValue);
         sectionNode.ChildNodes.First(n => n.Name.Equals("div", StringComparison.OrdinalIgnoreCase) && n.Id.Equals("div8", StringComparison.OrdinalIgnoreCase)).InnerHtml

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/DateFieldTagHelperFixture.cs
@@ -93,8 +93,8 @@ public class DateFieldTagHelperFixture : IDisposable
         HtmlNode? sectionNode = doc.DocumentNode.ChildNodes.First(n => n.HasClass("component-with-dates"));
 
         // Assert
-        sectionNode.ChildNodes[1].InnerHtml.Should().Be("05/04/2012");
-        sectionNode.ChildNodes[3].InnerHtml.Should().Be("05/04/2012 00:00:00");
+        sectionNode.ChildNodes[1].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
+        sectionNode.ChildNodes[3].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.CurrentCulture));
         sectionNode.ChildNodes[5].InnerHtml.Should().Be(TestConstants.DateTimeValue.ToString(CultureInfo.CurrentCulture));
         sectionNode.ChildNodes[9].InnerHtml.Should().Contain("04.05.2012");
     }

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Integration.Tests/Fixtures/TagHelpers/RichTextFieldTagHelperFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Globalization;
+using System.Net;
 using System.Text.Encodings.Web;
 using FluentAssertions;
 using HtmlAgilityPack;
@@ -70,7 +71,8 @@ public class RichTextFieldTagHelperFixture : IDisposable
 
         // Assert
         // check scenario that RichTextTagHelper does not reset values of another helpers.
-        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain("12/12/2019");
+        DateTime expectedDate = DateTime.Parse("12.12.19", CultureInfo.InvariantCulture);
+        sectionNode.ChildNodes.First(n => n.Name.Equals("textarea", StringComparison.OrdinalIgnoreCase)).InnerText.Should().Contain(expectedDate.ToString("MM/dd/yyyy", CultureInfo.CurrentCulture));
     }
 
     [Fact]

--- a/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.RenderingEngine.Tests/TagHelpers/Fields/DateTagHelperFixture.cs
@@ -123,23 +123,46 @@ public class DateTagHelperFixture
     }
 
     [Theory]
-    [AutoNSubstituteData]
-    public void Process_ScDateTagWithCustomFormat_GeneratesCustomDateFormatOutput(
-        DateTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
+    [InlineData("en-US")]
+    [InlineData("da-DK")]
+    [InlineData("uk-UA")]
+    public void Process_ScDateTagWithCustomFormat_GeneratesCustomDateFormatOutput(string cultureName)
     {
         // Arrange
-        const string dateFormat = "MM/dd/yyyy H:mm";
-        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag;
-        sut.DateFormat = dateFormat;
-        sut.For = GetModelExpression(new DateField(_date));
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo testCulture = new CultureInfo(cultureName);
 
-        // Act
-        sut.Process(tagHelperContext, tagHelperOutput);
+        try
+        {
+            CultureInfo.CurrentCulture = testCulture;
+            CultureInfo.CurrentUICulture = testCulture;
 
-        // Assert
-        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.InvariantCulture));
+            const string dateFormat = "MM/dd/yyyy H:mm";
+            DateTagHelper sut = new DateTagHelper(new EditableChromeRenderer());
+            TagHelperContext tagHelperContext = new TagHelperContext([], new Dictionary<object, object>(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+            TagHelperOutput tagHelperOutput = new TagHelperOutput(string.Empty, [], (_, _) =>
+            {
+                DefaultTagHelperContent tagHelperContent = new();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+            tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag;
+            sut.DateFormat = dateFormat;
+            sut.For = GetModelExpression(new DateField(_date));
+
+            // Act
+            sut.Process(tagHelperContext, tagHelperOutput);
+
+            // Assert - Expect culture-specific formatting based on current culture
+            string expected = _date.ToString(dateFormat, testCulture);
+            tagHelperOutput.Content.GetContent().Should().Be(expected);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [Theory]
@@ -258,23 +281,46 @@ public class DateTagHelperFixture
     }
 
     [Theory]
-    [AutoNSubstituteData]
-    public void Process_ScDateTagWithAspDataAttributeWithCustomFormat_GeneratesCustomDateFormatOutput(
-        DateTagHelper sut,
-        TagHelperContext tagHelperContext,
-        TagHelperOutput tagHelperOutput)
+    [InlineData("en-US")]
+    [InlineData("da-DK")]
+    [InlineData("uk-UA")]
+    public void Process_ScDateTagWithAspDataAttributeWithCustomFormat_GeneratesCustomDateFormatOutput(string cultureName)
     {
         // Arrange
-        string dateFormat = "MM/dd/yyyy H:mm";
-        tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag;
-        sut.DateFormat = dateFormat;
-        sut.DateModel = new DateField(_date);
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo testCulture = new CultureInfo(cultureName);
 
-        // Act
-        sut.Process(tagHelperContext, tagHelperOutput);
+        try
+        {
+            CultureInfo.CurrentCulture = testCulture;
+            CultureInfo.CurrentUICulture = testCulture;
 
-        // Assert
-        tagHelperOutput.Content.GetContent().Should().Be(_date.ToString(dateFormat, CultureInfo.InvariantCulture));
+            string dateFormat = "MM/dd/yyyy H:mm";
+            DateTagHelper sut = new DateTagHelper(new EditableChromeRenderer());
+            TagHelperContext tagHelperContext = new TagHelperContext([], new Dictionary<object, object>(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+            TagHelperOutput tagHelperOutput = new TagHelperOutput(string.Empty, [], (_, _) =>
+            {
+                DefaultTagHelperContent tagHelperContent = new();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+            tagHelperOutput.TagName = RenderingEngineConstants.SitecoreTagHelpers.DateHtmlTag;
+            sut.DateFormat = dateFormat;
+            sut.DateModel = new DateField(_date);
+
+            // Act
+            sut.Process(tagHelperContext, tagHelperOutput);
+
+            // Assert - Expect culture-specific formatting based on current culture
+            string expected = _date.ToString(dateFormat, testCulture);
+            tagHelperOutput.Content.GetContent().Should().Be(expected);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     [Theory]


### PR DESCRIPTION
- Convert DateTagHelper unit tests to use InlineData pattern with multiple cultures (en-US, da-DK, uk-UA)
- Update integration tests to expect culture-aware date formatting instead of hardcoded US format
- Fix test failures when running with Danish (da-dk) culture where date separator changes from "/" to "-"
- Replace var declarations with explicit types in modified test methods
- Add System.Globalization using statements where needed

Files modified,
- DateTagHelperFixture.cs: Convert to multi-culture InlineData tests
- DateFieldTagHelperFixture.cs: Use CurrentCulture for date expectations
- AllFieldTagHelpersFixture.cs: Use CurrentCulture for date assertions
- RichTextFieldTagHelperFixture.cs: Handle culture-specific date formatting
- ViewFieldsBindingFixture.cs: Update date format expectations