### PR TITLE
<sc-editingscripts /> nullreference

### DIFF
--- a/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
+++ b/src/Sitecore.AspNetCore.SDK.Pages/TagHelpers/EditingScriptsTagHelper.cs
@@ -25,13 +25,12 @@ namespace Sitecore.AspNetCore.SDK.Pages.TagHelpers
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            ISitecoreRenderingContext renderingContext = ViewContext?.HttpContext.GetSitecoreRenderingContext() ??
-                                             throw new NullReferenceException(Resources.Exception_EditingScriptsTagHelperSitecoreRenderingContextNull);
+            ISitecoreRenderingContext? renderingContext = ViewContext?.HttpContext.GetSitecoreRenderingContext();
 
             output.TagName = string.Empty;
             string html = string.Empty;
 
-            if (renderingContext.Response?.Content?.Sitecore?.Context?.IsEditing ?? false)
+            if (renderingContext?.Response?.Content?.Sitecore?.Context?.IsEditing ?? false)
             {
                 EditingContext? editingContext = JsonSerializer.Deserialize<EditingContext>(renderingContext.Response?.Content.ContextRawData ?? string.Empty);
                 if (editingContext == null)

--- a/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
+++ b/tests/Sitecore.AspNetCore.SDK.Pages.Tests/TagHelpers/EditingScriptsTagHelperFixture.cs
@@ -54,7 +54,7 @@ public class EditingScriptsTagHelperFixture
 
     [Theory]
     [AutoNSubstituteData]
-    public async Task ProcessAsync_NoSitecoreContenxt_ExceptionIsThrown(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput)
+    public async Task ProcessAsync_NoSitecoreContext_EmptyResult(EditingScriptsTagHelper sut, TagHelperContext tagHelperContext, TagHelperOutput tagHelperOutput)
     {
         // Arrange
         ViewContext viewContext = new()
@@ -66,10 +66,10 @@ public class EditingScriptsTagHelperFixture
         sut.ViewContext = viewContext;
 
         // Act
-        Func<Task> act = async () => await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
+        await sut.ProcessAsync(tagHelperContext, tagHelperOutput);
 
         // Assert
-        await act.Should().ThrowAsync<NullReferenceException>();
+        tagHelperOutput.Content.GetContent().Should().BeEmpty();
     }
 
     [Theory]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Apply the label "bug" or "enhancement" as applicable. -->

## Description / Motivation
<!-- Describe your changes in detail -->
+ Removed throwing an error and rendering nothing instead for <sc-editingscripts /> when no ISitecoreRenderingContext is available
<!-- Why is this change required? What problem does it solve? -->
In case of Experience Edge unavailability the ISitecoreRenderingContext might be empty, there is no reason to throw an exception and crash the page from rendering. This tag is often used in a main layout (like it was on MVP Website) which is also used when rendering error pages without a Sitecore context. Having this tag helper on the page causes issues in such case while it's perfectly acceptable to have an empty result.
<!-- If it fixes an open issue, please link to the issue here. -->


## Testing

- [X] The Unit & Intergration tests are passing.
- [X] I have added the necessary tests to cover my changes.

## Terms
<!-- Place an X in the [] to check. -->

<!-- The Code of Conduct helps create a safe space for everyone. We require that everyone agrees to it. -->
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md).
